### PR TITLE
Add native support for a Magento 2 environment with a split database

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -23,6 +23,11 @@ if [[ -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.${WARDEN_ENV_SUBT}.yml" 
     DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.${WARDEN_ENV_SUBT}.yml")
 fi
 
+if [[ ${WARDEN_SPLITDB} -eq 1 && -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.yml" ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.yml")
+fi
+
 if [[ -f "${WARDEN_ENV_PATH}/.warden/warden-env.yml" ]]; then
     DOCKER_COMPOSE_ARGS+=("-f")
     DOCKER_COMPOSE_ARGS+=("${WARDEN_ENV_PATH}/.warden/warden-env.yml")

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -23,9 +23,14 @@ if [[ -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.${WARDEN_ENV_SUBT}.yml" 
     DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.${WARDEN_ENV_SUBT}.yml")
 fi
 
-if [[ ${WARDEN_SPLITDB} -eq 1 && -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.yml" ]]; then
+if [[ ${WARDEN_SPLIT_SALES} -eq 1 && -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.sales.yml" ]]; then
     DOCKER_COMPOSE_ARGS+=("-f")
-    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.yml")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.sales.yml")
+fi
+
+if [[ ${WARDEN_SPLIT_CHECKOUT} -eq 1 && -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.checkout.yml" ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.splitdb.checkout.yml")
 fi
 
 if [[ -f "${WARDEN_ENV_PATH}/.warden/warden-env.yml" ]]; then

--- a/environments/magento1.base.yml
+++ b/environments/magento1.base.yml
@@ -6,7 +6,6 @@ services:
     environment:
       - NGINX_TEMPLATE=magento1.conf
     depends_on:
-      - db
       - php-fpm
     volumes:
       - .${WARDEN_WEB_ROOT:-}/:/var/www/html:delegated

--- a/environments/magento2.base.yml
+++ b/environments/magento2.base.yml
@@ -3,8 +3,9 @@ services:
   nginx:
     hostname: nginx
     image: davidalger/warden:nginx-${NGINX_VERSION:-1.16}-alpine
+    environment:
+      - NGINX_TEMPLATE=magento2.conf
     depends_on:
-      - db
       - php-fpm
 
   varnish:

--- a/environments/magento2.splitdb.checkout.yml
+++ b/environments/magento2.splitdb.checkout.yml
@@ -3,17 +3,14 @@ services:
   nginx:
     depends_on:
       - checkoutdb
-      - salesdb
 
   php-fpm:
     depends_on:
       - checkoutdb
-      - salesdb
 
   php-debug:
     depends_on:
       - checkoutdb
-      - salesdb
 
   checkoutdb:
     hostname: checkoutdb
@@ -32,23 +29,5 @@ services:
       - warden
       - default
 
-  salesdb:
-    hostname: salesdb
-    image: mariadb:${MARIADB_VERSION:-10.3}
-    environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-magento}
-      - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
-      - MYSQL_USER=${MYSQL_USER:-magento}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
-    command:
-      - mysqld
-      - --max_allowed_packet=1024M
-    volumes:
-      - salesdbdata:/var/lib/mysql
-    networks:
-      - warden
-      - default
-
 volumes:
   checkoutdbdata:
-  salesdbdata:

--- a/environments/magento2.splitdb.checkout.yml
+++ b/environments/magento2.splitdb.checkout.yml
@@ -1,9 +1,5 @@
 version: '3.5'
 services:
-  nginx:
-    depends_on:
-      - checkoutdb
-
   php-fpm:
     depends_on:
       - checkoutdb

--- a/environments/magento2.splitdb.sales.yml
+++ b/environments/magento2.splitdb.sales.yml
@@ -1,9 +1,5 @@
 version: '3.5'
 services:
-  nginx:
-    depends_on:
-      - salesdb
-
   php-fpm:
     depends_on:
       - salesdb

--- a/environments/magento2.splitdb.sales.yml
+++ b/environments/magento2.splitdb.sales.yml
@@ -1,0 +1,33 @@
+version: '3.5'
+services:
+  nginx:
+    depends_on:
+      - salesdb
+
+  php-fpm:
+    depends_on:
+      - salesdb
+
+  php-debug:
+    depends_on:
+      - salesdb
+
+  salesdb:
+    hostname: salesdb
+    image: mariadb:${MARIADB_VERSION:-10.3}
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-magento}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
+      - MYSQL_USER=${MYSQL_USER:-magento}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+    command:
+      - mysqld
+      - --max_allowed_packet=1024M
+    volumes:
+      - salesdbdata:/var/lib/mysql
+    networks:
+      - warden
+      - default
+
+volumes:
+  salesdbdata:

--- a/environments/magento2.splitdb.yml
+++ b/environments/magento2.splitdb.yml
@@ -1,0 +1,54 @@
+version: '3.5'
+services:
+  nginx:
+    depends_on:
+      - checkoutdb
+      - salesdb
+
+  php-fpm:
+    depends_on:
+      - checkoutdb
+      - salesdb
+
+  php-debug:
+    depends_on:
+      - checkoutdb
+      - salesdb
+
+  checkoutdb:
+    hostname: checkoutdb
+    image: mariadb:${MARIADB_VERSION:-10.3}
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-magento}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
+      - MYSQL_USER=${MYSQL_USER:-magento}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+    command:
+      - mysqld
+      - --max_allowed_packet=1024M
+    volumes:
+      - checkoutdbdata:/var/lib/mysql
+    networks:
+      - warden
+      - default
+
+  salesdb:
+    hostname: salesdb
+    image: mariadb:${MARIADB_VERSION:-10.3}
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-magento}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
+      - MYSQL_USER=${MYSQL_USER:-magento}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+    command:
+      - mysqld
+      - --max_allowed_packet=1024M
+    volumes:
+      - salesdbdata:/var/lib/mysql
+    networks:
+      - warden
+      - default
+
+volumes:
+  checkoutdbdata:
+  salesdbdata:


### PR DESCRIPTION
By adding `WARDEN_SPLITDB=1` to the `.env` file, Warden will now properly configure and spin-up a split database system for Magento 2

After merge, two new `.env` variables will exist:

* `WARDEN_SPLIT_SALES` - when set to 1 will automatically created a salesdb host, with the same magento user/password/dbname
* `WARDEN_SPLIT_CHECKOUT` - when set to 1 will automatically create a checkoutdb host, with the same magento user/password/dbname

These two variables can be used independently or together in order to create a split-database environment.