### PR TITLE
Open dnsmasq to containers

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     container_name: dnsmasq
     image: jpillora/dnsmasq
     ports:
-      - "127.0.0.1:53:53/udp"
+      - "53:53/udp"
     volumes:
       - ~/.warden/etc/dnsmasq.conf:/etc/dnsmasq.conf
     labels:


### PR DESCRIPTION
Prior to this change I had problems with DNS resolution from within my custom container in the warden network. With this change I can see the outbound queries (for example bitbucket.org) in the output of `docker logs dnsmasq`.