### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       --docker.network=warden
       --docker.exposedByDefault=false
     ports:
+      - "8080:8080" # Traefik dashboard ui
       - "80:80"     # The HTTP port
       - "443:443"   # The HTTPS port
     volumes:


### PR DESCRIPTION
The addition of port mapping "8080:8080" allows for "localhost:8080" to display the Traefik dashboard and more easily obtain the dnsmasq/portainer urls, as well as utilize the other Traefik dashboard features. With the additional port mapping, since the "--api" command is being used, the dashboard "just works." If there's another suggested method for easily accessing portainer/dnsmasq ui/traefik dashboard, it's currently undocumented.