### PR TITLE
Add Blackfire.io support

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -33,6 +33,16 @@ if [[ -f "${WARDEN_ENV_PATH}/.warden/warden-env.${WARDEN_ENV_SUBT}.yml" ]]; then
     DOCKER_COMPOSE_ARGS+=("${WARDEN_ENV_PATH}/.warden/warden-env.${WARDEN_ENV_SUBT}.yml")
 fi
 
+if [[ ${WARDEN_BLACKFIRE} -eq 1 && -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.blackfire.base.yml" ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.blackfire.base.yml")
+fi
+
+if [[ ${WARDEN_BLACKFIRE} -eq 1 && -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.blackfire.${WARDEN_ENV_SUBT}.yml" ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}.blackfire.${WARDEN_ENV_SUBT}.yml")
+fi
+
 ## lookup internal (warden docker network) IP address of traefik container (do not fail if traefik is stopped)
 export TRAEFIK_ADDRESS="$(docker container inspect traefik \
     --format '{{.NetworkSettings.Networks.warden.IPAddress}}' 2>/dev/null || true)"

--- a/environments/magento1.blackfire.yml
+++ b/environments/magento1.blackfire.yml
@@ -1,0 +1,26 @@
+version: "3.5"
+services:
+  php-blackfire:
+    hostname: php-blackfire
+    image: davidalger/warden:mage1-fpm-${PHP_VERSION:-7.2}-blackfire
+    depends_on:
+      - db
+    volumes:
+      - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
+      - ~/.composer:/home/www-data/.composer:delegated
+      - .${WARDEN_WEB_ROOT:-}/:/var/www/html:delegated
+    networks:
+      - warden
+      - default
+
+  blackfire-agent:
+    hostname: blackfire-agent
+    image: blackfire/blackfire:latest
+    environment:
+      - BLACKFIRE_CLIENT_ID=${BLACKFIRE_CLIENT_ID}
+      - BLACKFIRE_CLIENT_TOKEN=${BLACKFIRE_CLIENT_TOKEN}
+      - BLACKFIRE_SERVER_ID=${BLACKFIRE_SERVER_ID}
+      - BLACKFIRE_SERVER_TOKEN=${BLACKFIRE_SERVER_TOKEN}
+    networks:
+      - warden
+      - default

--- a/environments/magento2.blackfire.base.yml
+++ b/environments/magento2.blackfire.base.yml
@@ -1,0 +1,22 @@
+version: "3.5"
+services:
+  php-blackfire:
+    hostname: php-blackfire
+    image: davidalger/warden:mage2-fpm-${PHP_VERSION:-7.2}-blackfire
+    depends_on:
+      - db
+    networks:
+      - warden
+      - default
+
+  blackfire-agent:
+    hostname: blackfire-agent
+    image: blackfire/blackfire:latest
+    environment:
+      - BLACKFIRE_CLIENT_ID=${BLACKFIRE_CLIENT_ID}
+      - BLACKFIRE_CLIENT_TOKEN=${BLACKFIRE_CLIENT_TOKEN}
+      - BLACKFIRE_SERVER_ID=${BLACKFIRE_SERVER_ID}
+      - BLACKFIRE_SERVER_TOKEN=${BLACKFIRE_SERVER_TOKEN}
+    networks:
+      - warden
+      - default

--- a/environments/magento2.blackfire.darwin.yml
+++ b/environments/magento2.blackfire.darwin.yml
@@ -1,0 +1,11 @@
+version: "3.5"
+services:
+  php-blackfire:
+    volumes:
+      - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
+      - ~/.composer:/home/www-data/.composer:delegated
+      - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:delegated
+      - appdata:/var/www/html
+
+volumes:
+  appdata:

--- a/environments/magento2.blackfire.linux-gnu.yml
+++ b/environments/magento2.blackfire.linux-gnu.yml
@@ -1,0 +1,7 @@
+version: "3.5"
+services:
+  php-blackfire:
+    volumes:
+      - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
+      - ~/.composer:/home/www-data/.composer
+      - .${WARDEN_WEB_ROOT:-}/:/var/www/html


### PR DESCRIPTION
In order to trigger Blackfire build, .env file must contain WARDEN_BLACKFIRE=1

The following env variables should be set for Blackfire:

- BLACKFIRE_CLIENT_ID
- BLACKFIRE_CLIENT_TOKEN
- BLACKFIRE_SERVER_ID
- BLACKFIRE_SERVER_TOKEN