### PR TITLE
Add info about Docker mounting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The below example demonstrates the from-scratch setup of the Magento 2 applicati
 
        warden env up -d
        warden sync start   ## Omit this if running on a Linux host (or if not used by env type)
+   
+   If you encounter an error about `Mounts denied…`, follow the instructions in the error message and run `warden env up -d` again.
 
 5. Drop into a shell within the project environment. Commands following this step in the setup procedure will be run from within the `php-fpm` docker container this launches you into:
 


### PR DESCRIPTION
Issue: If you try to use Warden in a directory outside the list of [default "File Sharing" directories](https://user-images.githubusercontent.com/129031/67260346-6af52800-f460-11e9-889a-75d68e76df5c.jpg), you'll get an error like the one I noted below.

While I'm sure any savvy user will read the error message and know what to do, I expect that some users will encounter this, so it makes sense that the readme would tip off the user to expect an error in this process. If you want me to update this PR to state what conditions would trigger this, let me know.

For the record, I got this error:

```
warden env up -d

example_db_1 is up-to-date
example_rabbitmq_1 is up-to-date
example_elasticsearch_1 is up-to-date
example_mailhog_1 is up-to-date
Starting example_php-fpm_1 ...
Starting example_php-debug_1 ... error

ERROR: for example_php-debug_1  Cannot start service php-debug: b'Mounts denied: \r\nThe path /server/sites/example.test/pub/media\r\nis not shared from OSStarting example_php-fpm_1   ... error
r more info.\r\n.'

ERROR: for example_php-fpm_1  Cannot start service php-fpm: b'Mounts denied: \r\nThe path /server/sites/example.test/pub/media\r\nis not shared from OS X and is not known to Docker.\r\nYou can configure shared paths from Docker -> Preferences... -> File Sharing.\r\nSee https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.\r\n.'
```

After adding `/server/sites/example.test/pub/media` to the File Sharing list, I was able to run `warden env up -d`