### PR TITLE
Added socat pkg to fpm images

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -4,7 +4,7 @@ FROM davidalger/php:${PHP_VERSION}-fpm
 ENV MAILHOG_HOST    mailhog
 ENV MAILHOG_PORT    1025
 
-RUN yum install -y which pv sudo bind-utils python36-pip mariadb102 bash-completion rsync \
+RUN yum install -y which pv sudo bind-utils python36-pip mariadb102 bash-completion rsync socat \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
This can be used to create a socket accessible to www-data user enabling it to utilize (for example) the /run/host-services/ssh-auth.sock that is new in Docker Desktop v2.2.0.0 and only accessible to root.