### PR TITLE
Route both example.com and *.example to application by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ networks:
 **Enhancements:**
 
 * Added automatic start of Mutagen sync on `env up` and `env start` when sync is not connected (issue [#90](https://github.com/davidalger/warden/issues/90))
+* Updated routing rules so Traefik will now by default route both example.com and *.example.com to application ([#111](https://github.com/davidalger/warden/pull/111) by [davidalger](https://github.com/davidalger))
 
 ## Version [0.2.4](https://github.com/davidalger/warden/tree/0.2.4) (2020-02-29)
 [All Commits](https://github.com/davidalger/warden/compare/0.2.3..0.2.4)

--- a/environments/laravel.base.yml
+++ b/environments/laravel.base.yml
@@ -20,7 +20,8 @@ services:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=1
-      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`)
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=
+          HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-nginx.loadbalancer.server.port=80
 
   php-fpm:
@@ -31,6 +32,7 @@ services:
       - TRAEFIK_SUBDOMAIN
       - NODE_VERSION=${NODE_VERSION:-10}
     extra_hosts:
+      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
     depends_on:
       - db
@@ -48,6 +50,7 @@ services:
       - NODE_VERSION=${NODE_VERSION:-10}
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
     extra_hosts:
+      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
     depends_on:
       - db

--- a/environments/magento1.base.yml
+++ b/environments/magento1.base.yml
@@ -19,7 +19,8 @@ services:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=1
-      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`)
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=
+          HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-nginx.loadbalancer.server.port=80
 
   php-fpm:
@@ -30,6 +31,7 @@ services:
       - TRAEFIK_SUBDOMAIN
       - NODE_VERSION=${NODE_VERSION:-10}
     extra_hosts:
+      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
     depends_on:
       - db
@@ -47,6 +49,7 @@ services:
       - NODE_VERSION=${NODE_VERSION:-10}
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
     extra_hosts:
+      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
     depends_on:
       - db

--- a/environments/magento2.base.yml
+++ b/environments/magento2.base.yml
@@ -18,7 +18,8 @@ services:
       - traefik.enable=${BYPASS_VARNISH:-false}
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=2
-      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`)
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=
+          HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-nginx.loadbalancer.server.port=80
 
   varnish:
@@ -30,7 +31,8 @@ services:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.priority=1
-      - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.rule=HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`)
+      - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.rule=
+          HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-varnish.loadbalancer.server.port=80
 
   php-fpm:
@@ -41,6 +43,7 @@ services:
       - TRAEFIK_SUBDOMAIN
       - NODE_VERSION=${NODE_VERSION:-10}
     extra_hosts:
+      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
     depends_on:
       - db
@@ -49,7 +52,7 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.priority=2
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.rule=
-          HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`)
+          (HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`))
             && (Path(`/livereload.js`) || Path(`/livereload`))
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.service=${WARDEN_ENV_NAME}-livereload
       - traefik.http.services.${WARDEN_ENV_NAME}-livereload.loadbalancer.server.port=35729
@@ -63,6 +66,7 @@ services:
       - NODE_VERSION=${NODE_VERSION:-10}
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
     extra_hosts:
+      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
     depends_on:
       - db


### PR DESCRIPTION
Changes the expression:
```
HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`)
```

to this:
```
HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
```

This extends the wildcard support added in 0.2.0 to also route the base domain enabling developers to use example.com rather than app.example.com as the domain name for their local project.
