### PR TITLE
Forward SSH Agent from Host into FPM Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 **Enhancements:**
 
 * Added MySQL 5.6 and 5.7 images to Quay repository for use with Warden environments
-* Native support for Integration Tests with `MySQL 5.7` running on `tempfs` memory
+* Added support for Integration, Unit and API Tests leveraging a `MySQL 5.7` container running on `tempfs` memory disk ([#121](https://github.com/davidalger/warden/pull/115) by @lbajsarowicz
+* Added `WARDEN_ALLURE` setting to control Allure separately from Selenium for use reporting on Integration and Unit tests ([#121](https://github.com/davidalger/warden/pull/117) by @lbajsarowicz
+* Added ssh agent forwarding support on both macOS and Linux hosts ([#121](https://github.com/davidalger/warden/pull/121) by @davidalger
 
 **Bug Fixes:**
 

--- a/environments/laravel.base.yml
+++ b/environments/laravel.base.yml
@@ -30,6 +30,7 @@ services:
     environment:
       - TRAEFIK_DOMAIN
       - TRAEFIK_SUBDOMAIN
+      - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
     extra_hosts:
       - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
@@ -47,6 +48,7 @@ services:
     environment:
       - TRAEFIK_DOMAIN
       - TRAEFIK_SUBDOMAIN
+      - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
     extra_hosts:

--- a/environments/laravel.darwin.yml
+++ b/environments/laravel.darwin.yml
@@ -3,3 +3,11 @@ services:
   nginx:
     environment:
       - XDEBUG_CONNECT_BACK_HOST=${XDEBUG_CONNECT_BACK_HOST:-host.docker.internal}
+
+  php-fpm:
+    volumes:
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+
+  php-debug:
+    volumes:
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock

--- a/environments/laravel.linux-gnu.yml
+++ b/environments/laravel.linux-gnu.yml
@@ -1,0 +1,9 @@
+version: "3.5"
+services:
+  php-fpm:
+    volumes:
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/host-services/ssh-auth.sock
+
+  php-debug:
+    volumes:
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/host-services/ssh-auth.sock

--- a/environments/magento1.base.yml
+++ b/environments/magento1.base.yml
@@ -29,6 +29,7 @@ services:
     environment:
       - TRAEFIK_DOMAIN
       - TRAEFIK_SUBDOMAIN
+      - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
     extra_hosts:
       - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
@@ -46,6 +47,7 @@ services:
     environment:
       - TRAEFIK_DOMAIN
       - TRAEFIK_SUBDOMAIN
+      - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
     extra_hosts:

--- a/environments/magento1.darwin.yml
+++ b/environments/magento1.darwin.yml
@@ -3,3 +3,11 @@ services:
   nginx:
     environment:
       - XDEBUG_CONNECT_BACK_HOST=${XDEBUG_CONNECT_BACK_HOST:-host.docker.internal}
+
+  php-fpm:
+    volumes:
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+
+  php-debug:
+    volumes:
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock

--- a/environments/magento1.linux-gnu.yml
+++ b/environments/magento1.linux-gnu.yml
@@ -1,0 +1,9 @@
+version: "3.5"
+services:
+  php-fpm:
+    volumes:
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/host-services/ssh-auth.sock
+
+  php-debug:
+    volumes:
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/host-services/ssh-auth.sock

--- a/environments/magento2.base.yml
+++ b/environments/magento2.base.yml
@@ -41,6 +41,7 @@ services:
     environment:
       - TRAEFIK_DOMAIN
       - TRAEFIK_SUBDOMAIN
+      - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
     extra_hosts:
       - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
@@ -63,6 +64,7 @@ services:
     environment:
       - TRAEFIK_DOMAIN
       - TRAEFIK_SUBDOMAIN
+      - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
     extra_hosts:

--- a/environments/magento2.darwin.yml
+++ b/environments/magento2.darwin.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
       - ~/.composer:/home/www-data/.composer:delegated
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
       - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:delegated
       - appdata:/var/www/html
 
@@ -18,6 +19,7 @@ services:
     volumes:
       - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
       - ~/.composer:/home/www-data/.composer:delegated
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
       - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:delegated
       - appdata:/var/www/html
 

--- a/environments/magento2.linux-gnu.yml
+++ b/environments/magento2.linux-gnu.yml
@@ -8,10 +8,12 @@ services:
     volumes:
       - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
       - ~/.composer:/home/www-data/.composer
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/host-services/ssh-auth.sock
       - .${WARDEN_WEB_ROOT:-}/:/var/www/html
 
   php-debug:
     volumes:
       - ~/.warden/ssl/rootca/certs:/etc/ssl/warden-rootca-cert:ro
       - ~/.composer:/home/www-data/.composer
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/host-services/ssh-auth.sock
       - .${WARDEN_WEB_ROOT:-}/:/var/www/html


### PR DESCRIPTION
Docker Desktop now allows users to access the host’s SSH agent inside containers as of Docker Desktop 2.2.0.0 (released 2020-01-21) and later.

Reference docker/for-mac#410 and https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-community-2200

Last month I began researching how to do this. It requires a bit of effort to work around permissions issues with forwarding the socket since it is owned by root in the VM used on macOS but FPM containers are running as uid 1000. To work towards solving this, I added `socat` to FPM images in Feburary and then implemented the necessary forward to the docker-entrypoint script: davidalger/warden@a5df7fef

This PR adds the necessary docker-compose configuration to successfully forward the ssh-agento into `php-fpm` and `php-debug` containers on both macOS and Linux hosts across Magento 1, Magento 2 and Laravel environment types.

Simplest way to test this (and see it working) is to attempt a connection to Github (assuming your public key is authorized on Github that is):

```
$ ssh -T git@github.com
Hi davidalger! You've successfully authenticated, but GitHub does not provide shell access.
```

Another way to see it work is to simply run `ssh-add -l` once inside a php-fpm container to list keys in the agent. For example 

```
davidalger@hylfing:11:17 AM:/sites/example$ warden shell
www-data@example-php-fpm:04:17 PM:/var/www/html$ ssh-add -l
error fetching identities for protocol 1: agent refused operation
2048 SHA256:CYCgnAYUJ7NebFrZ8WMzqTE4AXek+iTxwno/0V6GUJI davidmalger@gmail.com (RSA)
```

Note that `agent refused operation` in the output of ssh-add is not indicative of a problem. As long as the keys show up and it shows you something other than (for example) `Could not open a connection to your authentication agent.` it means it's working as expected.
