### PR TITLE
FIX: Resolve issue with `selenium-hub` freeze

### DIFF
--- a/environments/magento2/magento2.selenium.base.yml
+++ b/environments/magento2/magento2.selenium.base.yml
@@ -3,7 +3,7 @@ services:
   selenium-hub:
     container_name: ${WARDEN_ENV_NAME}_selenium-hub
     hostname: selenium-hub
-    image: selenium/hub:3.8.1
+    image: selenium/hub:latest
     environment:
       GRID_TIMEOUT: 0
       GRID_BROWSER_TIMEOUT: 0


### PR DESCRIPTION
After running Suite's `<before>` section, the MFTF froze.
That was caused by the bug in Selenium HUB `3.8.1`

I verified that `selenium/hub` version is independent and compatible with `selenium/chrome:3.8.1`

As a result, I update the Hub version to `latest`.

@davidalger You can also mirror those images to your repo.