### PR TITLE
Rollback `tmpfs` to `tmp` paths of tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## UNRELEASED [x.y.z](https://github.com/davidalger/warden/tree/x.y.z) (yyyy-mm-dd)
 [All Commits](https://github.com/davidalger/warden/compare/0.4.0..develop)
 
+**Bug Fixes:**
+
+* Removed `tmpfs` volumes from sub-directories of `/var/www/html` when `WARDEN_TEST_DB=1` was set due to compatibility issues ([#139](https://github.com/davidalger/warden/pull/139) by @lbajsarowicz)
+
 ## Version [0.4.0](https://github.com/davidalger/warden/tree/0.4.0) (2020-04-02)
 [All Commits](https://github.com/davidalger/warden/compare/0.3.1..0.4.0)
 

--- a/environments/magento2/magento2.tests.yml
+++ b/environments/magento2/magento2.tests.yml
@@ -13,7 +13,6 @@ services:
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on
     volumes:
-      - tmp-cache:/var/cache
       - tmp-dbdata:/var/lib/mysql
 
 volumes:

--- a/environments/magento2/magento2.tests.yml
+++ b/environments/magento2/magento2.tests.yml
@@ -16,24 +16,8 @@ services:
       - tmp-cache:/var/cache
       - tmp-dbdata:/var/lib/mysql
 
-  php-fpm:
-    volumes:
-      - tmp-files:/var/www/html/dev/tests/integration/tmp/
-
-  php-debug:
-    volumes:
-      - tmp-files:/var/www/html/dev/tests/integration/tmp/
-
 volumes:
   tmp-dbdata:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  tmp-cache:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-  tmp-files:
     driver_opts:
       type: tmpfs
       device: tmpfs


### PR DESCRIPTION
Due to the issues reported, related to integration / api-functional tests mount directories not behaving properly, rolling back the mount, leaving only database mount on tmpfs.
