### PR TITLE
Use Mutagen pause/resume on stopped environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## UNRELEASED [x.y.z](https://github.com/davidalger/warden/tree/x.y.z) (yyyy-mm-dd)
 [All Commits](https://github.com/davidalger/warden/compare/0.4.0..develop)
 
+**Enhancements:**
+
+* Added pause, resume and monitor to `warden sync` command
+* Changed Mutagen sync to pause on `warden env stop` and resume on `warden env up -d`
+
 ## Version [0.4.1](https://github.com/davidalger/warden/tree/0.4.1) (2020-04-11)
 [All Commits](https://github.com/davidalger/warden/compare/0.4.0..0.4.1)
 

--- a/commands/sync.cmd
+++ b/commands/sync.cmd
@@ -64,6 +64,18 @@ case "${WARDEN_PARAMS[0]}" in
                     fi
                     printf .; sleep 1; done; echo
         ;;
+    monitor)
+        ## monitor only sessions labeled with this env name
+        mutagen sync monitor --label-selector "warden-sync=${WARDEN_ENV_NAME}"
+        ;;
+    pause)
+        ## pause only sessions labeled with this env name
+        mutagen sync pause --label-selector "warden-sync=${WARDEN_ENV_NAME}"
+        ;;
+    resume)
+        ## resume only sessions labeled with this env name
+        mutagen sync resume --label-selector "warden-sync=${WARDEN_ENV_NAME}"
+        ;;
     stop)
         ## terminate only sessions labeled with this env name
         mutagen sync terminate --label-selector "warden-sync=${WARDEN_ENV_NAME}"

--- a/commands/sync.help
+++ b/commands/sync.help
@@ -14,5 +14,8 @@ WARDEN_USAGE=$(cat <<EOF
   stop            Stops the mutagen sync for the current project environment
   list            Lists mutagen session status for current project environment
                   and optionally (with -v) the full configuration
+  pause           Pauses the mutagen sync for the current project environment
+  resume          Resumes the mutagen sync for the current project environment
+  monitor         Continously lists mutagen session status for current project environment               
 EOF
 )


### PR DESCRIPTION
Mutagen is able to pause and resume sync sessions. I added pause/resume/monitor to the `warden sync` command. Additionally I changed the automatic Mutagen behaviour for the warden environment commands.

Now the following should happen:

- `warden env up -d` when run for the first time should trigger `warden sync start` as before
- `warden env down` should trigger `warden sync stop` as before
- `warden env stop` should now trigger `warden sync pause` (you can check the status should say paused under `warden sync list`
- `warden env up -d` when run for a previously stopped environment should trigger `warden sync resume` provided the underlying php-fpm container still has the same container id (you can check `warden sync list` should have the same synchronisation identifier) and we have a paused session 