### PR TITLE
Add images for all available elasticsearch 7.x versions

### DIFF
--- a/images/elasticsearch/7.0/Dockerfile
+++ b/images/elasticsearch/7.0/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.1
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/images/elasticsearch/7.1/Dockerfile
+++ b/images/elasticsearch/7.1/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/images/elasticsearch/7.2/Dockerfile
+++ b/images/elasticsearch/7.2/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.2.1
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/images/elasticsearch/7.3/Dockerfile
+++ b/images/elasticsearch/7.3/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.2
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/images/elasticsearch/7.4/Dockerfile
+++ b/images/elasticsearch/7.4/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.4.2
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/images/elasticsearch/7.6/Dockerfile
+++ b/images/elasticsearch/7.6/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu

--- a/images/elasticsearch/7.7/Dockerfile
+++ b/images/elasticsearch/7.7/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
Currently images were only available for ES 5.6, 6.8 and 7.5. This update brings support tags to 5.6, 6.8 and any 7.x version currently available.