### PR TITLE
Give composer all the memory

### DIFF
--- a/environments/magento2/magento2.base.yml
+++ b/environments/magento2/magento2.base.yml
@@ -43,6 +43,7 @@ services:
       - TRAEFIK_SUBDOMAIN
       - SSH_AUTH_SOCK=/tmp/ssh-auth.sock
       - NODE_VERSION=${NODE_VERSION:-10}
+      - COMPOSER_MEMORY_LIMIT=-1
     volumes:
       - ${WARDEN_SSL_DIR}/rootca/certs:/etc/ssl/warden-rootca-cert:ro
       - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:delegated


### PR DESCRIPTION
Increasingly commonly Composer is requiring more than the PHP memory_limit, this change prevents that issue by allowing composer to exceed the memory limit