### PR TITLE
Prompt user if extant .env file would be overwritten by running env-init

### DIFF
--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -16,6 +16,8 @@ if test -f "${WARDEN_ENV_PATH}/.env"; then
   done
 fi
 
+# TODO: Prompt user for inputs when arguments remain unspecified
+
 WARDEN_ENV_NAME="${WARDEN_PARAMS[0]:-}"
 WARDEN_ENV_TYPE="${WARDEN_PARAMS[1]:-}"
 

--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -4,6 +4,7 @@
 source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(pwd -P)"
 
+# Prompt user if there is an extant .env file to ensure they intend to overwrite
 if test -f "${WARDEN_ENV_PATH}/.env"; then
   while true; do
     read -p $'\033[32mA warden env file already exists at '"${WARDEN_ENV_PATH}/.env"$'; would you like to overwrite? y/n\033[0m ' resp
@@ -14,8 +15,6 @@ if test -f "${WARDEN_ENV_PATH}/.env"; then
     esac
   done
 fi
-
-# TODO: Prompt user for inputs when arguments remain unspecified
 
 WARDEN_ENV_NAME="${WARDEN_PARAMS[0]:-}"
 WARDEN_ENV_TYPE="${WARDEN_PARAMS[1]:-}"

--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -4,7 +4,17 @@
 source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(pwd -P)"
 
-# TODO: If the .env file already exists; prompt user instead of overwriting
+if test -f "${WARDEN_ENV_PATH}/.env"; then
+  while true; do
+    read -p $'\033[32mA warden env file already exists at '"${WARDEN_ENV_PATH}/.env"$'; would you like to overwrite? y/n\033[0m ' resp
+    case $resp in
+      [Yy]*) echo "Overwriting extant .env file"; break;;
+      [Nn]*) exit;;
+      *) echo "Please answer (y)es or (n)o";;
+    esac
+  done
+fi
+
 # TODO: Prompt user for inputs when arguments remain unspecified
 
 WARDEN_ENV_NAME="${WARDEN_PARAMS[0]:-}"
@@ -112,10 +122,10 @@ if [[ "${WARDEN_ENV_TYPE}" == "laravel" ]]; then
 
 		CACHE_DRIVER=redis
 		SESSION_DRIVER=redis
-		
+
 		REDIS_HOST=redis
 		REDIS_PORT=6379
-		
+
 		MAIL_DRIVER=sendmail
 	EOT
 fi


### PR DESCRIPTION
PR replaces a TODO: with bash scripting that prompts the user to confirm that .env should be overwritten.

**Testing** 

- Pull PR
- Create a new, empty directory, and from that directory, run `warden env-init test magento2`; assert that the `.env` file is created as normal
- Make a change to the `.env` file
- Run `warden env-init test magento2` again; when prompted, answer `n`; assert that the change you made previously is still in the file
- Run `warden env-init test magento2` again; when prompted, answer `y`; assert that the change you made previously is no longer there
- Run `warden env-init test magento2` again; when prompted, answer anything other than `y` or `n`; assert that you are asked to provide a valid answer