### PR TITLE
Prompt unspecified env init inputs

### DIFF
--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -19,15 +19,23 @@ fi
 WARDEN_ENV_NAME="${WARDEN_PARAMS[0]:-}"
 
 # If warden environment name was not provided, prompt user for it
-if [ -z "$WARDEN_ENV_NAME"]; then
+while [ -z "$WARDEN_ENV_NAME" ]; do
   read -p $'\033[32mAn environment name was not provided; please enter one:\033[0m ' WARDEN_ENV_NAME
-fi
+done
 
 WARDEN_ENV_TYPE="${WARDEN_PARAMS[1]:-}"
 
 # If warden environment type was not provided, prompt user for it
-if [ -z "$WARDEN_ENV_TYPE"]; then
-  read -p $'\033[32mAn environment type was not provided; please choose one of [magento1, magento2, laravel, symfony]:\033[0m ' WARDEN_ENV_TYPE
+if [ -z "$WARDEN_ENV_TYPE" ]; then
+  while true; do
+    read -p $'\033[32mAn environment type was not provided; please choose one of [magento1, magento2, laravel, symfony]:\033[0m ' WARDEN_ENV_TYPE
+    case $WARDEN_ENV_TYPE in
+      magento1) break;;
+      magento2) break;;
+      laravel) break;;
+      symfony) break;;
+    esac
+  done
 fi
 
 # Verify the auto-select and/or type path resolves correctly before setting it

--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -16,13 +16,19 @@ if test -f "${WARDEN_ENV_PATH}/.env"; then
   done
 fi
 
-# TODO: Prompt user for inputs when arguments remain unspecified
-
 WARDEN_ENV_NAME="${WARDEN_PARAMS[0]:-}"
+
+# If warden environment name was not provided, prompt user for it
+if [ -z "$WARDEN_ENV_NAME"]; then
+  read -p $'\033[32mAn environment name was not provided; please enter one:\033[0m ' WARDEN_ENV_NAME
+fi
+
 WARDEN_ENV_TYPE="${WARDEN_PARAMS[1]:-}"
 
-# Require the user inputs the required environment name parameter
-[[ ! ${WARDEN_ENV_NAME} ]] && >&2 echo -e "\033[31mMissing required argument. Please use --help to to print usage.\033[0m" && exit 1
+# If warden environment type was not provided, prompt user for it
+if [ -z "$WARDEN_ENV_TYPE"]; then
+  read -p $'\033[32mAn environment type was not provided; please choose one of [magento1, magento2, laravel, symfony]:\033[0m ' WARDEN_ENV_TYPE
+fi
 
 # Verify the auto-select and/or type path resolves correctly before setting it
 assertValidEnvType || exit $?


### PR DESCRIPTION
PR replaces a TODO: with bash scripting that prompts the user for a warden environment name and a warden environment type if they were not provided when `env-init` was called.

**Testing** 

- Pull PR
- Create a new, empty directory, and from that directory, run `warden env-init test magento2`; assert that the `.env` file is created as normal
- Delete the .env file created above
- Run `warden env-init`; when prompted for an environment name, hit enter - you should be prompted until you provide a name. Provide one.
- You should be prompted for an environment type, hit enter - you should be prompted until you provide a valid environment type. Provide one.
- Assert that the generated .env file contains the correct environment name and environment type