### PR TITLE
Implement ability to create per-user and per-project custom commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Updated `env-init` command to prompt user for required arguments when missing ([#170](https://github.com/davidalger/warden/pull/170) by @Lunaetic)
 * Added support for Magepack advanced JS bundling ([#138](https://github.com/davidalger/warden/pull/138) by @vbuck)
 * Added a new `shopware` environment type including Mutagen configuration for file sync on macOS (issue [#169](https://github.com/davidalger/warden/issues/169))
+* Added support for implementing custom commands in `~/.warden/commands` or `<project>/.warden/commands` ([#172](https://github.com/davidalger/warden/pull/172) by @davidalger)
 
 **Bug Fixes:**
 

--- a/bin/warden
+++ b/bin/warden
@@ -52,11 +52,13 @@ if (( "$#" )); then
     shift
   elif [[ -f "${WARDEN_ENV_PATH}/.warden/commands/${1}.cmd" ]]; then
     WARDEN_CMD_VERB="$1"
+    WARDEN_CMD_ANYARGS+=("$1")
     WARDEN_CMD_EXEC="${WARDEN_ENV_PATH}/.warden/commands/${1}.cmd"
     WARDEN_CMD_HELP="${WARDEN_ENV_PATH}/.warden/commands/${1}.help"
     shift
   elif [[ -f "${WARDEN_HOME_DIR}/commands/${1}.cmd" ]]; then
     WARDEN_CMD_VERB="$1"
+    WARDEN_CMD_ANYARGS+=("$1")
     WARDEN_CMD_EXEC="${WARDEN_HOME_DIR}/commands/${1}.cmd"
     WARDEN_CMD_HELP="${WARDEN_HOME_DIR}/commands/${1}.help"
     shift

--- a/bin/warden
+++ b/bin/warden
@@ -13,6 +13,7 @@ readonly WARDEN_DIR="$(
   && pwd
 )"
 source "${WARDEN_DIR}/utils/core.sh"
+source "${WARDEN_DIR}/utils/env.sh"
 
 ## verify docker-compose is installed
 if ! which docker-compose >/dev/null; then
@@ -34,15 +35,34 @@ export readonly WARDEN_COMPOSER_DIR="${WARDEN_COMPOSER_DIR:-"$HOME/.composer"}"
 ## declare variables for flags and arguments
 declare WARDEN_HELP=
 declare WARDEN_PARAMS=()
-declare WARDEN_COMMAND=
-declare WARDEN_ANYARGS=(svc env db sync shell debug)
+declare WARDEN_CMD_VERB=
+declare WARDEN_CMD_EXEC=
+declare WARDEN_CMD_HELP=
+declare WARDEN_CMD_ANYARGS=(svc env db sync shell debug)
 
 ## parse first argument as command and determine validity
-if (( "$#" )) && [[ -f "${WARDEN_DIR}/commands/${1}.cmd" ]]; then
-  WARDEN_COMMAND="$1"
-  shift
-else
-  WARDEN_COMMAND=usage
+if (( "$#" )); then
+  ## local project directory if running within one; don't fail if it can't be found
+  WARDEN_ENV_PATH="$(locateEnvPath 2>/dev/null)" || true
+
+  if [[ -f "${WARDEN_DIR}/commands/${1}.cmd" ]]; then
+    WARDEN_CMD_VERB="$1"
+    WARDEN_CMD_EXEC="${WARDEN_DIR}/commands/${1}.cmd"
+    WARDEN_CMD_HELP="${WARDEN_DIR}/commands/${1}.help"
+    shift
+  elif [[ -f "${WARDEN_ENV_PATH}/.warden/commands/${1}.cmd" ]]; then
+    WARDEN_CMD_VERB="$1"
+    WARDEN_CMD_EXEC="${WARDEN_ENV_PATH}/.warden/commands/${1}.cmd"
+    WARDEN_CMD_HELP="${WARDEN_ENV_PATH}/.warden/commands/${1}.help"
+    shift
+  elif [[ -f "${WARDEN_HOME_DIR}/commands/${1}.cmd" ]]; then
+    WARDEN_CMD_VERB="$1"
+    WARDEN_CMD_EXEC="${WARDEN_HOME_DIR}/commands/${1}.cmd"
+    WARDEN_CMD_HELP="${WARDEN_HOME_DIR}/commands/${1}.help"
+    shift
+  else
+    WARDEN_HELP=1
+  fi
 fi
 
 ## parse arguments
@@ -54,10 +74,10 @@ while (( "$#" )); do
       ;;
     --) # end argument parsing (unless command is on 'anyargs' list and consumes anything as params)
       shift
-      containsElement "${WARDEN_COMMAND}" "${WARDEN_ANYARGS[@]}" || break
+      containsElement "${WARDEN_CMD_VERB}" "${WARDEN_CMD_ANYARGS[@]}" || break
       ;;
     -*|--*=) # unsupported flags (unless command is on 'anyargs' list and consumes anything as params)
-      containsElement "${WARDEN_COMMAND}" "${WARDEN_ANYARGS[@]}" && break
+      containsElement "${WARDEN_CMD_VERB}" "${WARDEN_CMD_ANYARGS[@]}" && break
       fatal "Unsupported flag $1"
       ;;
     *) # preserve positional arguments
@@ -73,4 +93,4 @@ if [[ ${WARDEN_HELP} ]]; then
 fi
 
 ## execute sub-command in context of this script
-source "${WARDEN_DIR}/commands/${WARDEN_COMMAND}.cmd"
+source "${WARDEN_CMD_EXEC}"

--- a/commands/db.cmd
+++ b/commands/db.cmd
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
-source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning

--- a/commands/debug.cmd
+++ b/commands/debug.cmd
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
-source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 

--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
-source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(pwd -P)"
 
 # Prompt user if there is an extant .env file to ensure they intend to overwrite

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
-source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning

--- a/commands/shell.cmd
+++ b/commands/shell.cmd
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
-source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 

--- a/commands/sign-certificate.cmd
+++ b/commands/sign-certificate.cmd
@@ -8,7 +8,7 @@ if [[ ! -f "${WARDEN_SSL_DIR}/rootca/certs/ca.cert.pem" ]]; then
 fi
 
 if (( ${#WARDEN_PARAMS[@]} == 0 )); then
-  echo -e "\033[33mCommand '${WARDEN_COMMAND}' requires a hostname as an argument, please use --help for details."
+  echo -e "\033[33mCommand '${WARDEN_CMD_VERB}' requires a hostname as an argument, please use --help for details."
   exit -1
 fi
 

--- a/commands/sync.cmd
+++ b/commands/sync.cmd
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
-source "${WARDEN_DIR}/utils/env.sh"
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 

--- a/commands/usage.cmd
+++ b/commands/usage.cmd
@@ -2,8 +2,8 @@
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
 ## load usage info for the given command falling back on default usage text
-if [[ -f "${WARDEN_DIR}/commands/${WARDEN_COMMAND}.help" ]]; then
-  source "${WARDEN_DIR}/commands/${WARDEN_COMMAND}.help"
+if [[ -f "${WARDEN_CMD_HELP}" ]]; then
+  source "${WARDEN_CMD_HELP}"
 else
   source "${WARDEN_DIR}/commands/usage.help"
 fi

--- a/utils/env.sh
+++ b/utils/env.sh
@@ -34,6 +34,7 @@ function locateEnvPath () {
 function loadEnvConfig () {
     local WARDEN_ENV_PATH="${1}"
     eval "$(grep "^WARDEN_" "${WARDEN_ENV_PATH}/.env")"
+    eval "$(grep "^TRAEFIK_" "${WARDEN_ENV_PATH}/.env")"
 
     WARDEN_ENV_NAME="${WARDEN_ENV_NAME:-}"
     WARDEN_ENV_TYPE="${WARDEN_ENV_TYPE:-}"


### PR DESCRIPTION
This PR implements the ability to create custom commands by adding `*.cmd` and `*.help` files sourced from `~/.warden/commands` and `<project>/.warden/commands`.

A use-case for this would be to implement a `warden bootstrap` command for M2 environments operating much in the same way as the `./tools/init.sh` script in https://github.com/davidalger/warden-env-magento2 does by adding a `.warden/commands/bootstrap.cmd` and `.warden/commands/bootstrap.help` file to the project.

Another use-case was outlined by @jamescowie at https://github.com/davidalger/warden/pull/64#issuecomment-573112736 using the `~/.warden/commands` on a per-user basis to provide a set of workflows specific to their org, while using Warden as the workflow tool.

This is something which was been requested on #120 as well as the initial POC for it on PR #64 (thank you @rafashkembi for first posing the idea to everyone in there!)

Some benefits to doing this also means some aspects of these scripts (as they interact with the warden environment itself) can become simpler. For example, any functions available in a Warden execution chain will be available to these custom commands since Warden is sourcing them into it's own context, not running them as sub-processes. You can see that in some of the sections of removed code and more robust help messaging here: https://github.com/davidalger/warden-env-magento2/pull/8/files


