### PR TITLE
Update 'warden up' references to 'warden svc up' in docs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -17,7 +17,7 @@ Installing Warden
 Warden may be installed via [Homebrew](https://brew.sh/) on both macOS and Linux hosts:
 
     brew install davidalger/warden/warden
-    warden up
+    warden svc up
 
 ### Alternative Installation
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -28,4 +28,4 @@ Warden may be installed by cloning the repository to the directory of your choic
     git clone -b master https://github.com/davidalger/warden.git /opt/warden
     echo 'export PATH="/opt/warden/bin:$PATH"' >> ~/.bashrc
     PATH="/opt/warden/bin:$PATH"
-    warden up
+    warden svc up

--- a/docs/services.md
+++ b/docs/services.md
@@ -20,4 +20,4 @@ The following options are available (with default values indicated):
     Setting ``TRAEFIK_LISTEN=0.0.0.0`` can be quite useful in some cases, but be aware that causing Traefik to listen for requests publicly poses a security risk when on public WiFi or networks otherwise outside of your control.
 ```
 
-After changing settings in `~/.warden/.env`, please run `warden up` to apply.
+After changing settings in `~/.warden/.env`, please run `warden svc up` to apply.


### PR DESCRIPTION
This was changed in version 0.6.0