### PR TITLE
Add detection of WSL when starting the debug container

### DIFF
--- a/commands/debug.cmd
+++ b/commands/debug.cmd
@@ -11,7 +11,7 @@ WARDEN_ENV_DEBUG_CONTAINER=${WARDEN_ENV_DEBUG_CONTAINER:-php-debug}
 WARDEN_ENV_DEBUG_HOST=${WARDEN_ENV_DEBUG_HOST:-}
 
 if [[ ${WARDEN_ENV_DEBUG_HOST} == "" ]]; then
-    if [[ $OSTYPE =~ ^darwin ]]; then
+    if [[ $OSTYPE =~ ^darwin || "$(< /proc/sys/kernel/osrelease)" == *Microsoft ]]; then
         WARDEN_ENV_DEBUG_HOST=host.docker.internal
     else
         WARDEN_ENV_DEBUG_HOST=$(


### PR DESCRIPTION
The current code for `warden debug` does not detect WSL based environments and instead identifies them as standard Linux. This becomes a problem when trying to configure the Xdebug remote connect address. The Windows version of Docker has the magic "host.docker.internal" hostname that the Linux version of Docker does not have. Additionally, the fallback method of remote IP detection fails to generate the correct IP address on a WSL setup. This test is the suggested way of detecting a WSL Linux system.

https://github.com/microsoft/WSL/issues/423#issuecomment-221627364