### PR TITLE
Adjust documentation for Warden 0.8 and Magento 2.4

### DIFF
--- a/docs/configuration/magento2-testing.md
+++ b/docs/configuration/magento2-testing.md
@@ -56,6 +56,9 @@ All the necessary files are located in `dev/tests/integration/`:
        'db-password' => 'magento',
        'db-name' => 'magento_integration_tests',
        'backend-frontname' => 'backend',
+       'search-engine' => 'elasticsearch7',
+       'elasticsearch-host' => 'elasticsearch',
+       'elasticsearch-port' => 9200,
        'admin-user' => \Magento\TestFramework\Bootstrap::ADMIN_NAME,
        'admin-password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
        'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,
@@ -87,9 +90,7 @@ All the necessary files are located in `dev/tests/integration/`:
     return [
         'customer/password/limit_password_reset_requests_method' => 0,
         'admin/security/admin_account_sharing' => 1,
-        'admin/security/limit_password_reset_requests_method' => 0,
-        'catalog/search/engine' => 'elasticsearch6',
-        'catalog/search/elasticsearch6_server_hostname' => 'elasticsearch',
+        'admin/security/limit_password_reset_requests_method' => 0
     ]; 
    ``` 
    
@@ -219,3 +220,5 @@ To run Acceptance tests you need to [configure the MFTF environment](mftf.md). O
 
 For more information about Debugging MFTF - please follow the [Magento Functional Testing Framework](mftf.md) section.
 The process of debugging is based on VNC connection to the Chrome instance.
+
+You can connect to Chrome session with `warden vnc` command.

--- a/docs/configuration/magento2-testing.md
+++ b/docs/configuration/magento2-testing.md
@@ -192,9 +192,9 @@ All the MFTF-related operations are operated by `vendor/bin/mftf`, necessary fil
 To run Acceptance tests you need to [configure the MFTF environment](mftf.md). Once you've done that, follow these steps to run the tests.
 
 1. Make sure that you enabled following in your `.env` file:
-   	- `WARDEN_SELENIUM` - Responsible for running virtual browser for your tests
+    - `WARDEN_SELENIUM` - Responsible for running virtual browser for your tests
     - `WARDEN_ALLURE` - Responsible for test results reporting
-   	- `WARDEN_SELENIUM_DEBUG` - Enables you to preview the tests with VNC
+    - `WARDEN_SELENIUM_DEBUG` - Enables you to preview the tests with VNC
 1. Run `vendor/bin/mftf build:project`, the configuration files will be generated in `dev/tests/acceptance`.
 1. Adjust `dev/tests/acceptance/.env` file by setting:
     - `MAGENTO_BASE_URL`

--- a/docs/configuration/magento2-testing.md
+++ b/docs/configuration/magento2-testing.md
@@ -191,6 +191,10 @@ All the MFTF-related operations are operated by `vendor/bin/mftf`, necessary fil
 
 To run Acceptance tests you need to [configure the MFTF environment](mftf.md). Once you've done that, follow these steps to run the tests.
 
+1. Make sure that you enabled following in your `.env` file:
+   	- `WARDEN_SELENIUM` - Responsible for running virtual browser for your tests
+    - `WARDEN_ALLURE` - Responsible for test results reporting
+   	- `WARDEN_SELENIUM_DEBUG` - Enables you to preview the tests with VNC
 1. Run `vendor/bin/mftf build:project`, the configuration files will be generated in `dev/tests/acceptance`.
 1. Adjust `dev/tests/acceptance/.env` file by setting:
     - `MAGENTO_BASE_URL`


### PR DESCRIPTION
1. Adjusted Elasticsearch configuration for Integration Tests
2. Added notice about `warden vnc` command