### PR TITLE
Change all :delegated mounts to :cached mounts to preserve existing behavior of mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## UNRELEASED [x.y.z](https://github.com/davidalger/warden/tree/x.y.z) (yyyy-mm-dd)
 [All Commits](https://github.com/davidalger/warden/compare/0.8.1..develop)
 
+**Enhancements:**
+
+* Changed all `:delegated` mounts to `:cached` mounts to preserve existing behavior of mounts when new behavior in Docker Desktop Edge 2.3.2.0 is promoted to stable channel ([#204](https://github.com/davidalger/warden/pull/204) by @davidalger)
 
 ## Version [0.8.1](https://github.com/davidalger/warden/tree/0.8.1) (2020-07-30)
 [All Commits](https://github.com/davidalger/warden/compare/0.8.0..0.8.1)

--- a/environments/includes/blackfire.base.yml
+++ b/environments/includes/blackfire.base.yml
@@ -2,8 +2,8 @@ version: "3.5"
 
 x-volumes: &volumes
   - ${WARDEN_SSL_DIR}/rootca/certs:/etc/ssl/warden-rootca-cert:ro
-  - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:delegated
-  - .${WARDEN_WEB_ROOT:-}/:/var/www/html:delegated
+  - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:cached
+  - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
 
 x-extra_hosts: &extra_hosts
     - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}

--- a/environments/includes/nginx.base.yml
+++ b/environments/includes/nginx.base.yml
@@ -11,6 +11,6 @@ services:
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-nginx.loadbalancer.server.port=80
     volumes:
-      - .${WARDEN_WEB_ROOT:-}/:/var/www/html:delegated
+      - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
     environment:
       - XDEBUG_CONNECT_BACK_HOST=${XDEBUG_CONNECT_BACK_HOST:-''}

--- a/environments/includes/php-fpm.base.yml
+++ b/environments/includes/php-fpm.base.yml
@@ -2,8 +2,8 @@ version: "3.5"
 
 x-volumes: &volumes
   - ${WARDEN_SSL_DIR}/rootca/certs:/etc/ssl/warden-rootca-cert:ro
-  - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:delegated
-  - .${WARDEN_WEB_ROOT:-}/:/var/www/html:delegated
+  - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:cached
+  - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
 
 x-extra_hosts: &extra_hosts
     - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}

--- a/environments/magento1/magento1.blackfire.darwin.yml
+++ b/environments/magento1/magento1.blackfire.darwin.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-volumes: &volumes
-  - .${WARDEN_WEB_ROOT:-}/media:/var/www/html/media:delegated
+  - .${WARDEN_WEB_ROOT:-}/media:/var/www/html/media:cached
   - appdata:/var/www/html
 
 x-environment: &environment

--- a/environments/magento1/magento1.darwin.yml
+++ b/environments/magento1/magento1.darwin.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-volumes: &volumes
-  - .${WARDEN_WEB_ROOT:-}/media:/var/www/html/media:delegated
+  - .${WARDEN_WEB_ROOT:-}/media:/var/www/html/media:cached
   - appdata:/var/www/html
 
 x-environment: &environment

--- a/environments/magento2/magento2.blackfire.darwin.yml
+++ b/environments/magento2/magento2.blackfire.darwin.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-volumes: &volumes
-  - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:delegated
+  - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:cached
   - appdata:/var/www/html
 
 x-environment: &environment

--- a/environments/magento2/magento2.darwin.yml
+++ b/environments/magento2/magento2.darwin.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-volumes: &volumes
-  - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:delegated
+  - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:cached
   - appdata:/var/www/html
 
 x-environment: &environment

--- a/environments/magento2/magento2.magepack.darwin.yml
+++ b/environments/magento2/magento2.magepack.darwin.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-volumes: &volumes
-  - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:delegated
+  - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:cached
   - appdata:/var/www/html
 
 services:

--- a/environments/shopware/shopware.darwin.yml
+++ b/environments/shopware/shopware.darwin.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 
 x-volumes: &volumes
-  - .${WARDEN_WEB_ROOT:-}/public/media:/var/www/html/public/media:delegated
+  - .${WARDEN_WEB_ROOT:-}/public/media:/var/www/html/public/media:cached
   - appdata:/var/www/html
 
 x-environment: &environment


### PR DESCRIPTION
This PR changes all `:delegated` usages in docker-compose configuration files to `:cached` which currently functions identically as has been noted as the BC way to preserve existing behavior of delegated mounts.

Reference https://docs.docker.com/docker-for-mac/mutagen/, docker/for-mac#1592. docker/for-mac#4590 for details. As of Docker Desktop Edge 2.3.2.0 the `:delegated` flag on a shared volume will automatically enable synchronization (via Mutagen) dramatically changing the expected and natural behavior of currently delegated mounts. Warden is currently using delegated mounts to specifically mount into containers things which should not be synced via Mutagen too avoid a performance penalty (large quantities of media files) and as a default for mount on Mac OS systems for better default performance characteristics where Mutagen syncs are not implemented.

Given that `:cached` and `:delegated` apparently have identical implementations currently (despite Docker documentation making a distinction) the use of `:cached` will not functionally change anything but will allow Warden to be forward compatible with changes seen on the horizon on Docker Desktop Edge channel.