### PR TITLE
Remove deprecated first-class commands down, restart, start, stop, and up

### DIFF
--- a/commands/down.cmd
+++ b/commands/down.cmd
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
-
-warning "This command is deprecated as of 0.6.0 and will be removed in 0.7.0; please use 'warden svc down' instead."
-
-trap '' ERR
-"${WARDEN_DIR}/bin/warden" svc down "${WARDEN_PARAMS[@]}" "$@"

--- a/commands/restart.cmd
+++ b/commands/restart.cmd
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
-
-warning "This command is deprecated as of 0.6.0 and will be removed in 0.7.0; please use 'warden svc restart' instead."
-
-trap '' ERR
-"${WARDEN_DIR}/bin/warden" svc restart "${WARDEN_PARAMS[@]}" "$@"

--- a/commands/start.cmd
+++ b/commands/start.cmd
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
-
-warning "This command is deprecated as of 0.6.0 and will be removed in 0.7.0; please use 'warden svc start' instead."
-
-trap '' ERR
-"${WARDEN_DIR}/bin/warden" svc start "${WARDEN_PARAMS[@]}" "$@"

--- a/commands/stop.cmd
+++ b/commands/stop.cmd
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
-
-warning "This command is deprecated as of 0.6.0 and will be removed in 0.7.0; please use 'warden svc stop' instead."
-
-trap '' ERR
-"${WARDEN_DIR}/bin/warden" svc stop "${WARDEN_PARAMS[@]}" "$@"

--- a/commands/up.cmd
+++ b/commands/up.cmd
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
-
-warning "This command is deprecated as of 0.6.0 and will be removed in 0.7.0; please use 'warden svc up' instead."
-
-trap '' ERR
-"${WARDEN_DIR}/bin/warden" svc up -d "${WARDEN_PARAMS[@]}" "$@"


### PR DESCRIPTION
From 0.6.0 release notes:

* Added `warden svc` command to control global services replacing `warden start`, `warden stop`, `warden up`, `warden down`, and `warden restart` and offering further flexibility as this works similar to warden env in that any verb known to docker-compose may be used in orchestrating global services such as traefik, dnsmasq and portainer; for example, warden svc up does what warden up did previously.

When this was done, these old commands were kept and printed a warning such as the following:

> WARNING: This command is deprecated as of 0.6.0 and will be removed in 0.7.0; please use 'warden svc start' instead.

These commands were for various reasons not cleaned up in the 0.7.0 release as originally planned. This removes them now requiring the use of `warden svc <verb>` to control global services.