### PR TITLE
Add wsl2 support for warden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## UNRELEASED [x.y.z](https://github.com/davidalger/warden/tree/x.y.z) (yyyy-mm-dd)
 [All Commits](https://github.com/davidalger/warden/compare/0.9.0..develop)
 
+**Bug Fixes:**
+
+* Fixed bug on WSL2 where Xdebug connect back host was improperly set ([#213](https://github.com/davidalger/warden/pull/213) by @iihor-sviziev)
+
 ## Version [0.9.0](https://github.com/davidalger/warden/tree/0.9.0) (2020-08-06)
 [All Commits](https://github.com/davidalger/warden/compare/0.8.2..0.9.0)
 

--- a/commands/debug.cmd
+++ b/commands/debug.cmd
@@ -11,7 +11,7 @@ WARDEN_ENV_DEBUG_CONTAINER=${WARDEN_ENV_DEBUG_CONTAINER:-php-debug}
 WARDEN_ENV_DEBUG_HOST=${WARDEN_ENV_DEBUG_HOST:-}
 
 if [[ ${WARDEN_ENV_DEBUG_HOST} == "" ]]; then
-    if [[ $OSTYPE =~ ^darwin || "$(< /proc/sys/kernel/osrelease)" == *Microsoft || "$(< /proc/sys/kernel/osrelease)" == *microsoft* ]]; then
+    if [[ $OSTYPE =~ ^darwin ]] || grep -sqi microsoft /proc/sys/kernel/osrelease; then
         WARDEN_ENV_DEBUG_HOST=host.docker.internal
     else
         WARDEN_ENV_DEBUG_HOST=$(

--- a/commands/debug.cmd
+++ b/commands/debug.cmd
@@ -11,7 +11,7 @@ WARDEN_ENV_DEBUG_CONTAINER=${WARDEN_ENV_DEBUG_CONTAINER:-php-debug}
 WARDEN_ENV_DEBUG_HOST=${WARDEN_ENV_DEBUG_HOST:-}
 
 if [[ ${WARDEN_ENV_DEBUG_HOST} == "" ]]; then
-    if [[ $OSTYPE =~ ^darwin || "$(< /proc/sys/kernel/osrelease)" == *Microsoft ]]; then
+    if [[ $OSTYPE =~ ^darwin || "$(< /proc/sys/kernel/osrelease)" == *Microsoft || "$(< /proc/sys/kernel/osrelease)" == *microsoft* ]]; then
         WARDEN_ENV_DEBUG_HOST=host.docker.internal
     else
         WARDEN_ENV_DEBUG_HOST=$(

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -29,6 +29,10 @@ if [[ ${WARDEN_ENV_TYPE} == "magento2" ]]; then
     WARDEN_RABBITMQ=${WARDEN_RABBITMQ:-1}
 fi
 
+if [[ ${XDEBUG_CONNECT_BACK_HOST} == '' && "$(< /proc/sys/kernel/osrelease)" == *microsoft* ]]; then
+    export XDEBUG_CONNECT_BACK_HOST=host.docker.internal
+fi
+
 ## configure docker-compose files
 DOCKER_COMPOSE_ARGS=()
 

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -29,7 +29,8 @@ if [[ ${WARDEN_ENV_TYPE} == "magento2" ]]; then
     WARDEN_RABBITMQ=${WARDEN_RABBITMQ:-1}
 fi
 
-if [[ ${XDEBUG_CONNECT_BACK_HOST} == '' && "$(< /proc/sys/kernel/osrelease)" == *microsoft* ]]; then
+## WSL1/WSL2 are GNU/Linux env type but still run Docker Desktop
+if [[ ${XDEBUG_CONNECT_BACK_HOST} == '' ]] && grep -sqi microsoft /proc/sys/kernel/osrelease; then
     export XDEBUG_CONNECT_BACK_HOST=host.docker.internal
 fi
 


### PR DESCRIPTION
Fixes https://github.com/davidalger/warden/issues/212

As a workaround now we can add following lines in order to have working xdebug with warden on WSL2:
```
XDEBUG_CONNECT_BACK_HOST=host.docker.internal
WARDEN_ENV_DEBUG_HOST=host.docker.internal
```
After this change warden debug works fine without adding any new params to .env file.

this is retrieved from wsl2:
```
$ echo "$(< /proc/sys/kernel/osrelease)"
4.19.104-microsoft-standard
```