### PR TITLE
Scan for partial env in WARDEN_HOME_DIR to allow customizations

### DIFF
--- a/utils/env.sh
+++ b/utils/env.sh
@@ -82,7 +82,11 @@ function appendEnvPartialIfExists () {
         "${WARDEN_DIR}/environments/includes/${PARTIAL_NAME}.base.yml" \
         "${WARDEN_DIR}/environments/includes/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
         "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.base.yml" \
-        "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml"
+        "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
+        "${WARDEN_HOME_DIR}/environments/includes/${PARTIAL_NAME}.base.yml" \
+        "${WARDEN_HOME_DIR}/environments/includes/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
+        "${WARDEN_HOME_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.base.yml" \
+        "${WARDEN_HOME_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml"
     do
         if [[ -f "${PARTIAL_PATH}" ]]; then
             DOCKER_COMPOSE_ARGS+=("-f" "${PARTIAL_PATH}")


### PR DESCRIPTION
This addition allows users to customize the docker-compose files by adding similarly-named files in the `~/.warden/environments...` directory.