### PR TITLE
Add ability to define custom environment templates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 /.sync
 /Icon?
 /.idea
+/environments/*
+!/environments/includes
+!/environments/laravel
+!/environments/local
+!/environments/magento1
+!/environments/magento2
+!/environments/shopware
+!/environments/symfony
+!/environments/wordpress

--- a/commands/env-init.cmd
+++ b/commands/env-init.cmd
@@ -8,7 +8,7 @@ if test -f "${WARDEN_ENV_PATH}/.env"; then
   while true; do
     read -p $'\033[32mA warden env file already exists at '"${WARDEN_ENV_PATH}/.env"$'; would you like to overwrite? y/n\033[0m ' resp
     case $resp in
-      [Yy]*) echo "Overwriting extant .env file"; break;;
+      [Yy]*) echo "Overwriting existing .env file"; break;;
       [Nn]*) exit;;
       *) echo "Please answer (y)es or (n)o";;
     esac
@@ -65,9 +65,7 @@ if [[ "${WARDEN_ENV_TYPE}" == "magento1" ]]; then
 		BLACKFIRE_SERVER_ID=
 		BLACKFIRE_SERVER_TOKEN=
 	EOT
-fi
-
-if [[ "${WARDEN_ENV_TYPE}" == "magento2" ]]; then
+elif [[ "${WARDEN_ENV_TYPE}" == "magento2" ]]; then
   cat >> "${WARDEN_ENV_PATH}/.env" <<-EOT
 
 		WARDEN_DB=1
@@ -100,9 +98,7 @@ if [[ "${WARDEN_ENV_TYPE}" == "magento2" ]]; then
 		BLACKFIRE_SERVER_ID=
 		BLACKFIRE_SERVER_TOKEN=
 	EOT
-fi
-
-if [[ "${WARDEN_ENV_TYPE}" == "laravel" ]]; then
+elif [[ "${WARDEN_ENV_TYPE}" == "laravel" ]]; then
   cat >> "${WARDEN_ENV_PATH}/.env" <<-EOT
 
 		MARIADB_VERSION=10.4
@@ -135,9 +131,7 @@ if [[ "${WARDEN_ENV_TYPE}" == "laravel" ]]; then
 
 		MAIL_DRIVER=sendmail
 	EOT
-fi
-
-if [[ "${WARDEN_ENV_TYPE}" =~ ^symfony|shopware$ ]]; then
+elif [[ "${WARDEN_ENV_TYPE}" =~ ^symfony|shopware$ ]]; then
   cat >> "${WARDEN_ENV_PATH}/.env" <<-EOT
 
 		WARDEN_DB=1
@@ -153,9 +147,7 @@ if [[ "${WARDEN_ENV_TYPE}" =~ ^symfony|shopware$ ]]; then
 		REDIS_VERSION=5.0
 		VARNISH_VERSION=6.0
 	EOT
-fi
-
-if [[ "${WARDEN_ENV_TYPE}" == "wordpress" ]]; then
+elif [[ "${WARDEN_ENV_TYPE}" == "wordpress" ]]; then
   cat >> "${WARDEN_ENV_PATH}/.env" <<-EOT
 
 		MARIADB_VERSION=10.4
@@ -174,5 +166,14 @@ if [[ "${WARDEN_ENV_TYPE}" == "wordpress" ]]; then
 		DB_DATABASE=wordpress
 		DB_USERNAME=wordpress
 		DB_PASSWORD=wordpress
+	EOT
+else
+  cat >> "${WARDEN_ENV_PATH}/.env" <<-EOT
+
+		WARDEN_DB=1
+
+		MARIADB_VERSION=10.3
+		PHP_VERSION=7.4
+		NGINX_VERSION=1.16
 	EOT
 fi


### PR DESCRIPTION
By changing the `if ... fi` checks for environment initialization to `if ... elif ... fi` structures we can allow for a "generic" environment setup. This should make it easier for people to define their own environment templates.

Also added some rules to .gitignore to exclude any added environments, except the ones that already exist.