### PR TITLE
Mutagen configuration at project folder

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -134,9 +134,17 @@ export TRAEFIK_ADDRESS="$(docker container inspect traefik \
     ' 2>/dev/null || true
 )"
 
+if [[ $OSTYPE =~ ^darwin ]]; then
+    export MUTAGEN_SYNC_FILE="${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
+
+    if [[ -f "${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]; then
+        export MUTAGEN_SYNC_FILE="${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
+    fi
+fi
+
 ## pause mutagen sync if needed
 if [[ "${WARDEN_PARAMS[0]}" == "stop" ]] \
-    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]
+    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]]
 then
     warden sync pause
 fi
@@ -148,7 +156,7 @@ docker-compose \
 
 ## resume mutagen sync if available and php-fpm container id hasn't changed
 if ([[ "${WARDEN_PARAMS[0]}" == "up" ]] || [[ "${WARDEN_PARAMS[0]}" == "start" ]]) \
-    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]] \
+    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]] \
     && [[ $(warden sync list | grep -i 'Status: \[Paused\]' | wc -l | awk '{print $1}') == "1" ]] \
     && [[ $(warden env ps -q php-fpm) ]] \
     && [[ $(docker container inspect $(warden env ps -q php-fpm) --format '{{ .State.Status }}') = "running" ]] \
@@ -159,7 +167,7 @@ fi
 
 ## start mutagen sync if needed
 if ([[ "${WARDEN_PARAMS[0]}" == "up" ]] || [[ "${WARDEN_PARAMS[0]}" == "start" ]]) \
-    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]] \
+    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]] \
     && [[ $(warden sync list | grep -i 'Connection state: Connected' | wc -l | awk '{print $1}') != "2" ]] \
     && [[ $(warden env ps -q php-fpm) ]] \
     && [[ $(docker container inspect $(warden env ps -q php-fpm) --format '{{ .State.Status }}') = "running" ]]
@@ -169,7 +177,7 @@ fi
 
 ## stop mutagen sync if needed
 if [[ "${WARDEN_PARAMS[0]}" == "down" ]] \
-    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]
+    && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]]
 then
     warden sync stop
 fi

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -137,8 +137,8 @@ export TRAEFIK_ADDRESS="$(docker container inspect traefik \
 if [[ $OSTYPE =~ ^darwin ]]; then
     export MUTAGEN_SYNC_FILE="${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
 
-    if [[ -f "${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]; then
-        export MUTAGEN_SYNC_FILE="${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
+    if [[ -f "${WARDEN_ENV_PATH}/.warden/mutagen.yml" ]]; then
+        export MUTAGEN_SYNC_FILE="${WARDEN_ENV_PATH}/.warden/mutagen.yml"
     fi
 fi
 

--- a/commands/sync.cmd
+++ b/commands/sync.cmd
@@ -28,8 +28,16 @@ if [[ $OSTYPE =~ ^darwin ]] && ! test $(version ${MUTAGEN_VERSION}) -ge $(versio
   exit 1
 fi
 
+if [[ $OSTYPE =~ ^darwin && -z "${MUTAGEN_SYNC_FILE}" ]]; then
+    export MUTAGEN_SYNC_FILE="${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
+
+    if [[ -f "${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]; then
+        export MUTAGEN_SYNC_FILE="${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
+    fi
+fi
+
 ## if no mutagen configuration file exists for the environment type, exit with error
-if [[ ! -f "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]; then
+if [[ ! -f "${MUTAGEN_SYNC_FILE}" ]]; then
   fatal "Mutagen configuration does not exist for environment type \"${WARDEN_ENV_TYPE}\""
 fi
 
@@ -40,7 +48,7 @@ case "${WARDEN_PARAMS[0]}" in
         mutagen sync terminate --label-selector "warden-sync=${WARDEN_ENV_NAME}"
 
         ## create sync session based on environment type configuration
-        mutagen sync create -c "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" \
+        mutagen sync create -c "${MUTAGEN_SYNC_FILE}" \
             --label "warden-sync=${WARDEN_ENV_NAME}" --ignore "${WARDEN_SYNC_IGNORE:-}" \
             "${WARDEN_ENV_PATH}${WARDEN_WEB_ROOT:-}" "docker://$(warden env ps -q php-fpm)/var/www/html"
 

--- a/commands/sync.cmd
+++ b/commands/sync.cmd
@@ -31,8 +31,8 @@ fi
 if [[ $OSTYPE =~ ^darwin && -z "${MUTAGEN_SYNC_FILE}" ]]; then
     export MUTAGEN_SYNC_FILE="${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
 
-    if [[ -f "${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]; then
-        export MUTAGEN_SYNC_FILE="${WARDEN_ENV_PATH}/.warden/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
+    if [[ -f "${WARDEN_ENV_PATH}/.warden/mutagen.yml" ]]; then
+        export MUTAGEN_SYNC_FILE="${WARDEN_ENV_PATH}/.warden/mutagen.yml"
     fi
 fi
 


### PR DESCRIPTION
This PR provide update for mutagen that allow create custom sync config at project folder

```
<project_folder>/.warden/mutagen.yml
```

### Reason

**Affected MacOS**
If you create local env type with `.warden/warden-env.yml` docker configuration like:
```
version: "3.5"
services:
  php-fpm:
    hostname: "${WARDEN_ENV_NAME}-php-fpm"
    image: docker.io/magenius/php-fpm:${PHP_VERSION:-7.4}${WARDEN_SVC_PHP_VARIANT:-}
    environment:
      - TRAEFIK_DOMAIN
      - TRAEFIK_SUBDOMAIN
      - COMPOSER_MEMORY_LIMIT=-1
    volumes:
      - appdata:/var/www/html
    extra_hosts:
      - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
      - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}

volumes:
  appdata: {}
```
you unable start file syncing with container.