### PR TITLE
Add `defer` to livereload script

### DIFF
--- a/docs/configuration/livereload.md
+++ b/docs/configuration/livereload.md
@@ -21,7 +21,7 @@ Magento 2 bundles an example grunt based server-side compilation workflow which 
            'default' => [
                'design' => [
                    'footer' => [
-                       'absolute_footer' => '<script src="/livereload.js?port=443"></script>'
+                       'absolute_footer' => '<script defer src="/livereload.js?port=443"></script>'
                    ]
                ]
            ]


### PR DESCRIPTION
Without defer, if livereload is not running, the browser will halt, looking for the script.

Myself and another developer run into an issue when Grunt (livereload) is not running, where our browser spends 5m+ trying to load livereload, and no other script runs until the load times out.