### PR TITLE
Add PHP 8.0 Image Builds

### DIFF
--- a/.github/workflows/docker-image-php-fpm.yml
+++ b/.github/workflows/docker-image-php-fpm.yml
@@ -15,13 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3", "7.4"]
+        php_version: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
+        include:
+          # IonCube and Source Guardian loaders do not yet exist for PHP 8.0
+          - php_version: "8.0"
+            php_variants: "cli fpm"
     steps:
     - uses: actions/checkout@v1
     - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"
       env:
         BUILD_GROUP: php-fpm
         PHP_VERSION: ${{ matrix.php_version }}
+        VARIANT_LIST: ${{ matrix.php_variants }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -31,7 +36,7 @@ jobs:
     needs: php-fpm
     strategy:
       matrix:
-        php_version: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3", "7.4"]
+        php_version: ["5.5", "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
     steps:
     - uses: actions/checkout@v1
     - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"
@@ -47,7 +52,7 @@ jobs:
     needs: php-fpm
     strategy:
       matrix:
-        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4"]
+        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
     steps:
     - uses: actions/checkout@v1
     - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -1,5 +1,6 @@
 ARG PHP_VERSION=
-FROM davidalger/php:${PHP_VERSION}-fpm-loaders
+ARG PHP_VARIANT="fpm-loaders"
+FROM davidalger/php:${PHP_VERSION}-${PHP_VARIANT}
 
 # Clear undesired settings from base fpm images
 ENV COMPOSER_ALLOW_SUPERUSER=

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -9,8 +9,9 @@ ENV COMPOSER_HOME=
 ENV MAILHOG_HOST    mailhog
 ENV MAILHOG_PORT    1025
 
-RUN yum install -y which pv sudo bind-utils python3-pip mariadb102 bash-completion rsync socat oathtool \
+RUN yum install -y which pv sudo bind-utils python3-pip bash-completion rsync socat oathtool \
         wget ack make gcc gcc-c++ automake autoconf crontabs \
+    && yum install --enablerepo=ius mariadb102 \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/images/php-fpm/debug/Dockerfile
+++ b/images/php-fpm/debug/Dockerfile
@@ -3,11 +3,7 @@ FROM docker.io/wardenenv/php-fpm:${PHP_VERSION}
 USER root
 
 RUN set -eux \
-    && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
-    && if (( ${PHP_VERSION} >= 73 )); \
-        then yum install -y php${PHP_VERSION}-pecl-xdebug; \
-        else yum install -y php${PHP_VERSION}u-xdebug; \
-    fi \
+    && yum install -y php-pecl-xdebug \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/images/php-fpm/magento1/debug/Dockerfile
+++ b/images/php-fpm/magento1/debug/Dockerfile
@@ -3,11 +3,7 @@ FROM docker.io/wardenenv/php-fpm:${PHP_VERSION}-magento1
 USER root
 
 RUN set -eux \
-    && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
-    && if (( ${PHP_VERSION} >= 73 )); \
-        then yum install -y php${PHP_VERSION}-pecl-xdebug; \
-        else yum install -y php${PHP_VERSION}u-xdebug; \
-    fi \
+    && yum install -y php-pecl-xdebug \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/images/php-fpm/magento2/debug/Dockerfile
+++ b/images/php-fpm/magento2/debug/Dockerfile
@@ -3,11 +3,7 @@ FROM docker.io/wardenenv/php-fpm:${PHP_VERSION}-magento2
 USER root
 
 RUN set -eux \
-    && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
-    && if (( ${PHP_VERSION} >= 73 )); \
-        then yum install -y php${PHP_VERSION}-pecl-xdebug; \
-        else yum install -y php${PHP_VERSION}u-xdebug; \
-    fi \
+    && yum install -y php-pecl-xdebug \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
- Introduces PHP 8.0 images. It's important to note these will NOT have either the IonCube loader nor Source Guardian loader installed as neither loader yet supports PHP 8
- Updates the debug image build files for compatibility with the new Remi based upstream images (see https://github.com/davidalger/docker-images-php/pull/4)

Related to:
- https://github.com/davidalger/warden/issues/270
- https://github.com/davidalger/warden/issues/267
- https://github.com/davidalger/warden/issues/277

