### PR TITLE
Add support to php-fpm image entrypoint to handle COMPOSER_VERSION=2

### DIFF
--- a/images/php-fpm/context/docker-entrypoint
+++ b/images/php-fpm/context/docker-entrypoint
@@ -33,6 +33,11 @@ then
   sudo n "${NODE_VERSION}"
 fi
 
+# Configure composer2 as default when specified
+if [[ "${COMPOSER_VERSION:-}" == "2" ]]; then
+  sudo cp /usr/bin/composer2 /usr/bin/composer
+fi
+
 # Resolve permission issues with directories auto-created by volume mounts; to use set CHOWN_DIR_LIST to
 # a list of directories (relative to working directory) to chown, walking up the paths to also chown each
 # specified parent directory. Example: "dir1/dir2 dir3" will chown dir1/dir2, then dir1 followed by dir3


### PR DESCRIPTION
Upstream images now COPY composer v1 to both composer and composer1. This allows us to simply copy whichever major version should be active overwriting the existing file while still having both versions available in the running container should they be needed, without having to download anything on container startup.

Without env var present:
```
$ docker run --rm -it wardenenv/php-fpm:7.4 bash -c 'echo; ls -1 /usr/bin/composer*; echo; composer -V'
sendmail_path = "/usr/local/bin/mhsendmail --smtp-addr='mailhog:1025'"

/usr/bin/composer
/usr/bin/composer1
/usr/bin/composer2

Composer version 1.10.20 2021-01-27 15:41:06
```

With composer v2 specified:

```
$ docker run --rm -it -e COMPOSER_VERSION=2 wardenenv/php-fpm:7.4 bash -c 'echo; ls -1 /usr/bin/composer*; echo; composer -V'
sendmail_path = "/usr/local/bin/mhsendmail --smtp-addr='mailhog:1025'"

/usr/bin/composer
/usr/bin/composer1
/usr/bin/composer2

Composer version 2.0.9 2021-01-27 16:09:27
```

See #296