### PR TITLE
[PHP-FPM] Mount bash history as separate volume to prevent cleaning after recreation

### DIFF
--- a/environments/includes/php-fpm.base.yml
+++ b/environments/includes/php-fpm.base.yml
@@ -4,6 +4,7 @@ x-volumes: &volumes
   - ${WARDEN_SSL_DIR}/rootca/certs:/etc/ssl/warden-rootca-cert:ro
   - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:cached
   - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
+  - bashhistory:/var/bash_history
 
 x-extra_hosts: &extra_hosts
     - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
@@ -24,6 +25,7 @@ services:
       - NODE_VERSION=${NODE_VERSION:-10}
       - COMPOSER_VERSION=${COMPOSER_VERSION:-1}
       - COMPOSER_MEMORY_LIMIT=-1
+      - HISTFILE=/var/bash_history/.bash_history
     volumes: *volumes
     extra_hosts: *extra_hosts
 
@@ -38,7 +40,10 @@ services:
       - COMPOSER_VERSION=${COMPOSER_VERSION:-1}
       - COMPOSER_MEMORY_LIMIT=-1
       - PHP_IDE_CONFIG=serverName=${WARDEN_ENV_NAME}-docker
+      - HISTFILE=/var/bash_history/.bash_history
     volumes: *volumes
     extra_hosts: *extra_hosts
     depends_on:
       - php-fpm
+volumes:
+  bashhistory:


### PR DESCRIPTION
**Resolver Issue:**
#289 Command history cleans up all the time