### PR TITLE
Fix socat service start failure

### DIFF
--- a/images/php-fpm/context/docker-entrypoint
+++ b/images/php-fpm/context/docker-entrypoint
@@ -18,7 +18,7 @@ sudo update-ca-trust
 if [[ -S /run/host-services/ssh-auth.sock ]] \
   && [[ "${SSH_AUTH_SOCK}" != "/run/host-services/ssh-auth.sock" ]]
 then
-  sudo rm -f ${SSH_AUTH_SOCK}
+  sudo rm -f "${SSH_AUTH_SOCK}"
   sudo bash -c "nohup socat UNIX-CLIENT:/run/host-services/ssh-auth.sock \
     UNIX-LISTEN:${SSH_AUTH_SOCK},fork,user=www-data,group=www-data 1>/var/log/socat-ssh-auth.log 2>&1 &"
 fi

--- a/images/php-fpm/context/docker-entrypoint
+++ b/images/php-fpm/context/docker-entrypoint
@@ -18,6 +18,7 @@ sudo update-ca-trust
 if [[ -S /run/host-services/ssh-auth.sock ]] \
   && [[ "${SSH_AUTH_SOCK}" != "/run/host-services/ssh-auth.sock" ]]
 then
+  sudo rm -f ${SSH_AUTH_SOCK}
   sudo bash -c "nohup socat UNIX-CLIENT:/run/host-services/ssh-auth.sock \
     UNIX-LISTEN:${SSH_AUTH_SOCK},fork,user=www-data,group=www-data 1>/var/log/socat-ssh-auth.log 2>&1 &"
 fi


### PR DESCRIPTION
After restarting php-fpm container on Ubuntu 20.04 we had missing ssh keys (computer restart, or just `warden env restart`), so we were getting the following issue during git clone via ssh:
> Permission denied (public key).

In the logs of socat we found following line:
> 2021/02/19 08:08:26 socat[180] E "/tmp/ssh-auth.sock" exists

My PR removes socket file if it exists before starting socat.

Note: seems like we don't have this issue on Mac OS because there `$SSH_AUTH_SOCK` is equal to `/run/host-services/ssh-auth.sock`, and we're not starting socat here

**Workaround**
```bash
warden env down && warden env up
```