### PR TITLE
Mount ssh directory as separate volume 

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -29,7 +29,7 @@ if [[ ${WARDEN_ENV_TYPE} != local ]]; then
     WARDEN_REDIS=${WARDEN_REDIS:-1}
 
     # define bash history folder for changing permissions
-    WARDEN_CHOWN_DIR_LIST="/bash_history ${WARDEN_CHOWN_DIR_LIST:-}"
+    WARDEN_CHOWN_DIR_LIST="/bash_history /home/www-data/.ssh ${WARDEN_CHOWN_DIR_LIST:-}"
 fi
 export CHOWN_DIR_LIST=${WARDEN_CHOWN_DIR_LIST:-}
 

--- a/environments/includes/php-fpm.base.yml
+++ b/environments/includes/php-fpm.base.yml
@@ -5,6 +5,7 @@ x-volumes: &volumes
   - ${WARDEN_COMPOSER_DIR}:/home/www-data/.composer:cached
   - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
   - bashhistory:/bash_history
+  - sshdirectory:/home/www-data/.ssh
 
 x-extra_hosts: &extra_hosts
     - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
@@ -49,3 +50,4 @@ services:
       - php-fpm
 volumes:
   bashhistory:
+  sshdirectory:

--- a/images/php-fpm/context/docker-entrypoint
+++ b/images/php-fpm/context/docker-entrypoint
@@ -47,7 +47,7 @@ for DIR in ${CHOWN_DIR_LIST:-}; do
     while :; do
       sudo chown www-data:www-data "${DIR}"
       DIR=$(dirname "${DIR}")
-      if [[ ${DIR} == "." ]] || [[ ${DIR} == "/" ]]; then
+      if [[ ${DIR} == "." ]] || [[ ${DIR} == "/" ]] || [[ ${DIR} == "/home" ]]; then
         break;
       fi
     done


### PR DESCRIPTION
This PR fixes a similar issue to https://github.com/davidalger/warden/issues/289, but with ssh known_hosts file.
Basically it does the same as  https://github.com/davidalger/warden/pull/304 and https://github.com/davidalger/warden/pull/308

**Steps to reproduce:**
1. start the environment and connect to GitHub:
```bash
warden env up
warden shell -T -c 'ssh git@github.com'
```
    first time it will ask you to confirm fingerprint, like this:
```
  The authenticity of host 'github.com (140.82.121.3)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
RSA key fingerprint is MD5:16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.121.3' (RSA) to the list of known hosts.
PTY allocation request failed on channel 0
Hi ihor-sviziev! You've successfully authenticated, but GitHub does not provide shell access.
Connection to github.com closed.
```
2. try again to run `warden shell -T -c 'ssh git@github.com'` - there should not be any additional confirmations
```
PTY allocation request failed on channel 0
Hi ihor-sviziev! You've successfully authenticated, but GitHub does not provide shell access.
Connection to github.com closed.
```
3. Stop the environment, run it again and try the same command again:
```bash
warden env down
warden env up
warden shell -T -c 'ssh git@github.com'
```


**Actual result:** (Before)
❌ known_hosts file is missing, it's asking again for confirming GitHub host:
```
  The authenticity of host 'github.com (140.82.121.4)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
RSA key fingerprint is MD5:16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.121.4' (RSA) to the list of known hosts.
PTY allocation request failed on channel 0
Hi ihor-sviziev! You've successfully authenticated, but GitHub does not provide shell access.
Connection to github.com closed.
```

**Expected result:** (After)
✔ known_hosts file is present, it already trusts to GitHub host:
```
PTY allocation request failed on channel 0
Hi ihor-sviziev! You've successfully authenticated, but GitHub does not provide shell access.
Connection to github.com closed.
```