### PR TITLE
Sample for building arm64 images with GH actions

### DIFF
--- a/.github/workflows/docker-image-elasticsearch.yml
+++ b/.github/workflows/docker-image-elasticsearch.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - uses: docker/setup-buildx-action@v1
     - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"
       env:
         BUILD_GROUP: elasticsearch

--- a/images/scripts/build.sh
+++ b/images/scripts/build.sh
@@ -94,6 +94,12 @@ for file in $(find ${SEARCH_PATH} -type f -name Dockerfile | sort -V); do
     fi
 
     printf "\e[01;31m==> building ${IMAGE_TAG} from ${BUILD_DIR}/Dockerfile with context ${BUILD_CONTEXT}\033[0m\n"
-    docker build -t "${IMAGE_TAG}" -f ${BUILD_DIR}/Dockerfile ${BUILD_ARGS[@]} ${BUILD_CONTEXT}
-    [[ $PUSH_FLAG ]] && docker push "${IMAGE_TAG}" || true
+
+    PUSH_ARG=
+    if [[ ${PUSH_FLAG} ]]; then
+      PUSH_ARG="--push"
+    fi
+
+    BUILD_PLATFORM="${BUILD_PLATFORM:-linux/amd64,linux/arm64}"
+    docker buildx build --platform "${BUILD_PLATFORM}" -t "${IMAGE_TAG}" -f ${BUILD_DIR}/Dockerfile ${BUILD_ARGS[@]} ${PUSH_ARG} ${BUILD_CONTEXT}
 done


### PR DESCRIPTION
With the rise of arm64 on Apple products, we've experienced that not all warden images are playing equally nice.

Based on some early feedback from some users at Vaimo, some images have problems running through the built-in x86 emulator.

Namely
- elasticsearch -> Platform-specific JVM
- varnish -> No official arm support
- redis -> qemu doesn't play nicely "qemu: uncaught target signal 11 (Segmentation fault) - core dumped"

This pull request (in its current form) is only a placeholder to facilitate a discussion on how (and if) Warden should approach providing support for Apple's new M1 silicon.

In this PR, I've simply added buildx support and default to building for both linux/amd64 and linux/arm64 architectures. 

Running this locally with `nektos/act` works (at least on my mid '15 macbook), but I'm no expert on this subject.
