### PR TITLE
add Access-Control-Allow-Origin * to magento2.conf to fix CORS issue …

### DIFF
--- a/images/nginx/context/etc/nginx/available.d/magento2.conf
+++ b/images/nginx/context/etc/nginx/available.d/magento2.conf
@@ -67,21 +67,12 @@ location /static/ {
         rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
     }
 
-    location ~* \.(ico|jpg|jpeg|png|gif|js|css|swf|json)$ {
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header Access-Control-Allow-Origin "*";     # Allow use from CDN origin
         expires +1y;
 
-        if (!-f $request_filename) {
-            rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
-        }
-    }
-
-    location ~* \.(eot|ttf|otf|svg|woff|woff2)$ {
-        add_header Access-Control-Allow-Origin *;
-        add_header Cache-Control "public";
-        add_header X-Frame-Options "SAMEORIGIN";
-        expires +1y;
         if (!-f $request_filename) {
             rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
         }

--- a/images/nginx/context/etc/nginx/available.d/magento2.conf
+++ b/images/nginx/context/etc/nginx/available.d/magento2.conf
@@ -67,7 +67,7 @@ location /static/ {
         rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
     }
 
-    location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$ {
+    location ~* \.(ico|jpg|jpeg|png|gif|js|css|swf|json)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";
         expires +1y;
@@ -76,6 +76,17 @@ location /static/ {
             rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
         }
     }
+
+    location ~* \.(eot|ttf|otf|svg|woff|woff2)$ {
+        add_header Access-Control-Allow-Origin *;
+        add_header Cache-Control "public";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires +1y;
+        if (!-f $request_filename) {
+            rewrite ^/static/?(.*)$ /static.php?resource=$1 last;
+        }
+    }
+
     location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
         add_header Cache-Control "no-store";
         add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
Resolves a CORS issue with loading fonts hosted in Magento in Mailhog.

See screenshot of the header added to the web font loaded in mailhog.
![image](https://user-images.githubusercontent.com/2175652/110964773-8ac11080-8321-11eb-9f26-a8d0883385ae.png)
