### PR TITLE
Laravel: increase read timeout to prevent 504s when debugging

### DIFF
--- a/images/nginx/context/etc/nginx/available.d/application.conf
+++ b/images/nginx/context/etc/nginx/available.d/application.conf
@@ -13,7 +13,7 @@ location ~ \.php$ {
     fastcgi_buffers 1024 4k;
     fastcgi_buffer_size 32k;
     fastcgi_busy_buffers_size 256k;
-    fastcgi_read_timeout 60s;
+    fastcgi_read_timeout 3200s;
 
     include fastcgi_params;
 

--- a/images/nginx/context/etc/nginx/available.d/application.conf
+++ b/images/nginx/context/etc/nginx/available.d/application.conf
@@ -13,7 +13,7 @@ location ~ \.php$ {
     fastcgi_buffers 1024 4k;
     fastcgi_buffer_size 32k;
     fastcgi_busy_buffers_size 256k;
-    fastcgi_read_timeout 3200s;
+    fastcgi_read_timeout 600s;
 
     include fastcgi_params;
 


### PR DESCRIPTION
When debugging a Laravel project, the site times out after 60 seconds because the `fastcgi_read_timeout` param is set to a low default value. Since this is a development environment, I am increasing this value to 3200s to match Magento configuration.