### PR TITLE
docs: Update docs about DNS resolution using systemd-resolved

### DIFF
--- a/docs/configuration/dns-resolver.md
+++ b/docs/configuration/dns-resolver.md
@@ -25,18 +25,12 @@ If you desire to have more than this route through the `dnsmasq` container, you 
 
 This approach works on most modern (systemd based) operating systems.
 
-`systemd-resolved` can we configured to forward the requests of `.test` TLD to another DNS server. The configuration file is typically located at `/etc/systemd/resolved.conf`. Change the file to contain the following lines.
+`systemd-resolved` can be configured to forward the requests of `.test` TLD to another DNS server. The configuration file is typically located at `/etc/systemd/resolved.conf` and `/etc/systemd/resolved.conf.d/*.conf`. Run the following commands to configure systemd-resolved:
 
-```text
-DNS=127.0.0.1
-Domains=~test
-```
-
-Restart the `systemd-resolved`
-
-```bash
-sudo systemctl restart systemd-resolved
-```
+    sudo mkdir -p /etc/systemd/resolved.conf.d
+    echo -e "[Resolve]\nDNS=127.0.0.1\nDomains=~test\n" \
+      | sudo tee /etc/systemd/resolved.conf.d/warden.conf > /dev/null
+    sudo systemctl restart systemctl-resolved
 
 #### Ubuntu resolvconf
 

--- a/docs/configuration/dns-resolver.md
+++ b/docs/configuration/dns-resolver.md
@@ -30,7 +30,7 @@ This approach works on most modern (systemd based) operating systems.
     sudo mkdir -p /etc/systemd/resolved.conf.d
     echo -e "[Resolve]\nDNS=127.0.0.1\nDomains=~test\n" \
       | sudo tee /etc/systemd/resolved.conf.d/warden.conf > /dev/null
-    sudo systemctl restart systemctl-resolved
+    sudo systemctl restart systemd-resolved
 
 #### Ubuntu resolvconf
 

--- a/docs/configuration/dns-resolver.md
+++ b/docs/configuration/dns-resolver.md
@@ -21,7 +21,9 @@ If you desire to have more than this route through the `dnsmasq` container, you 
 1.0.0.1
 ```
 
-#### Ubuntu systemd-resolved
+#### systemd-resolved
+
+This approach works on most modern (systemd based) operating systems.
 
 `systemd-resolved` can we configured to forward the requests of `.test` TLD to another DNS server. The configuration file is typically located at `/etc/systemd/resolved.conf`. Change the file to contain the following lines.
 
@@ -33,7 +35,7 @@ Domains=~test
 Restart the `systemd-resolved`
 
 ```bash
-sudo service systemd-resolved restart
+sudo systemctl restart systemd-resolved
 ```
 
 #### Ubuntu resolvconf


### PR DESCRIPTION
Usage of systemd-resolved is the most simple and out of the box configuration for any system that is shipped with systemd + systemd-resolved. So it shouldn't be Ubuntu specific!