### PR TITLE
Update PHP 8.0 image build to include Source Guardian support

### DIFF
--- a/.github/workflows/docker-image-php-fpm.yml
+++ b/.github/workflows/docker-image-php-fpm.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         php_version: ["7.2", "7.3", "7.4", "8.0"]
-        include:
-          # IonCube and Source Guardian loaders do not yet exist for PHP 8.0
-          - php_version: "8.0"
-            php_variant: "fpm"
     steps:
     - uses: actions/checkout@v1
     - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"


### PR DESCRIPTION
Source Guardian now has loaders for PHP 8.0, so this updates CI to use the `8.0-fpm-loaders` base image which was added to the upstream this morning: https://github.com/davidalger/docker-images-php/pull/8

Unfortunately IonCube loaders for PHP 8.0 still do not exist, and will thus continue to be omitted from the 8.0 images until IonCube gets their act together.