### PR TITLE
Downgrade to mysql 8.0.23

### DIFF
--- a/images/mysql/8.0/Dockerfile
+++ b/images/mysql/8.0/Dockerfile
@@ -1,1 +1,1 @@
-FROM mysql:8.0
+FROM mysql:8.0.23


### PR DESCRIPTION
Currently there is a problem with running Magento from mysql 8.0.24 and higher.
See changes on collations in mysql 8.0.24 -> https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-24.html