### PR TITLE
Add Blackfire CLI to Magento blackfire images

### DIFF
--- a/images/php-fpm/magento1/blackfire/Dockerfile
+++ b/images/php-fpm/magento1/blackfire/Dockerfile
@@ -8,6 +8,12 @@ RUN curl -o - "http://packages.blackfire.io/fedora/blackfire.repo" \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
+# Install the Blackfire Client to provide access to the CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -rf /tmp/blackfire
+
 COPY blackfire/etc/php.d/*.ini /etc/php.d/
 
 USER www-data

--- a/images/php-fpm/magento2/blackfire/Dockerfile
+++ b/images/php-fpm/magento2/blackfire/Dockerfile
@@ -7,6 +7,12 @@ RUN curl -o - "http://packages.blackfire.io/fedora/blackfire.repo" \
     && dnf install -y blackfire-php \
     && dnf clean all \
     && rm -rf /var/cache/dnf
+    
+# Install the Blackfire Client to provide access to the CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -rf /tmp/blackfire
 
 COPY blackfire/etc/php.d/*.ini /etc/php.d/
 


### PR DESCRIPTION
The BlackfireCLI was added in https://github.com/davidalger/warden/pull/188, but it doesn't work for Magento 2:
```bash
$ warden blackfire
OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: exec: "blackfire": executable file not found in $PATH: unknown
```

I found that it Blackfire CLI was added to base php-fpm image, but not to magento-specific images. This PR fixes this issue.

**Workaround** (while this PR still not merged):
You can run add backfire CLI manually by executing the following command:
```bash
warden env exec --user root php-blackfire bash -c 'mkdir -p /tmp/blackfire && curl -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire && mv /tmp/blackfire/blackfire /usr/bin/blackfire && rm -rf /tmp/blackfire'
```