### PR TITLE
Configure MySQL 8 image with skip-log-bin flag configured

### DIFF
--- a/images/mysql/8.0/Dockerfile
+++ b/images/mysql/8.0/Dockerfile
@@ -1,1 +1,3 @@
 FROM mysql:8.0
+
+COPY etc/mysql/conf.d/skip-bin-log.cnf /etc/mysql/conf.d/

--- a/images/mysql/context/etc/mysql/conf.d/skip-bin-log.cnf
+++ b/images/mysql/context/etc/mysql/conf.d/skip-bin-log.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+skip-log-bin


### PR DESCRIPTION
To quote MySQL 8.0 documentation:

> In earlier MySQL versions, binary logging was disabled by default…from MySQL 8.0, binary logging is enabled by default, whether or not you specify the --log-bin option.

On a local environment, binary logging is pointless overhead, and results in workarounds such as #354 being required for some application workloads.

When merged, a new `docker.io/wardenenv/mysql:8.0` image will be automatically built. Existing stacks where the old image is already present may be updated by running `warden env pull && warden env up`