### PR TITLE
Fix WSL2 paths on installations page

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -47,7 +47,7 @@ In order for DNS entries to be resolved either add them to your Windows hosts fi
     **For performance reasons code should be located in the WSL Linux home path or other WSL local path ~/code/projectname NOT the default /mnt/c path mapping.**
 ```
 
-GUI tools for Windows should use the network paths provided by WSL2: \\wsl$\Ubuntu-20.04\home\<USER>\<PROJECTPATH>.
+GUI tools for Windows should use the network paths provided by WSL2: `\\wsl$\Ubuntu-20.04\home\<USER>\<PROJECTPATH>`.
 
 ### Next Steps
 


### PR DESCRIPTION
Follow up on https://github.com/davidalger/warden/pull/422

https://docs.warden.dev/installing.html#windows-installation-via-wsl2
Before:
![image](https://user-images.githubusercontent.com/1873745/133219506-7bb1a320-0269-41e4-9256-15b22b8bc11e.png)
After:
![image](https://user-images.githubusercontent.com/1873745/133219976-478f1e72-14a8-41c0-b809-2f590cb2b779.png)

This change treats this path as a code to not lose the backslashes