### PR TITLE
Update default URL for ElasticsearchHQ

### DIFF
--- a/environments/includes/elasticsearch.base.yml
+++ b/environments/includes/elasticsearch.base.yml
@@ -23,6 +23,8 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.rule=Host(`elastichq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch-hq.loadbalancer.server.port=5000
+    environment:
+      - HQ_DEFAULT_URL=http://elasticsearch:9200
 
 volumes:
   esdata:


### PR DESCRIPTION
https://docs.elastichq.org/installation.html#environment-variables

This PR sets the correct the default URL: `http://elasticsearch:9200`