### PR TITLE
Increase default client_max_body_size to 5MB

### DIFF
--- a/images/nginx/context/etc/nginx/conf.d/default.conf
+++ b/images/nginx/context/etc/nginx/conf.d/default.conf
@@ -23,6 +23,7 @@ server {
     autoindex off;
     charset UTF-8;
 
+    client_max_body_size 5M;
     include /etc/nginx/available.d/${NGINX_TEMPLATE};
     include /etc/nginx/default.d/*.conf;
 }


### PR DESCRIPTION
1MB is fairly limiting for some very large Magento attributes, and since this is not intended to be used on production, I can't think of any negatives