### PR TITLE
Add `traefik.docker.network` label to specify docker network exclusively

### DIFF
--- a/environments/includes/allure.base.yml
+++ b/environments/includes/allure.base.yml
@@ -8,6 +8,7 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-allure.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-allure.rule=Host(`allure.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-allure.loadbalancer.server.port=4040
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
       # TODO; configure the Allure API; these rules result in allure sub-domain no longer routing
       # - traefik.http.routers.${WARDEN_ENV_NAME}-allure-api.tls=true
       # - traefik.http.routers.${WARDEN_ENV_NAME}-allure-api.rule=Host(`allure-api.${TRAEFIK_DOMAIN}`)

--- a/environments/includes/elasticsearch.base.yml
+++ b/environments/includes/elasticsearch.base.yml
@@ -8,6 +8,7 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch.rule=Host(`elasticsearch.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch.loadbalancer.server.port=9200
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -23,6 +24,7 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.rule=Host(`elastichq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch-hq.loadbalancer.server.port=5000
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
     environment:
       - HQ_DEFAULT_URL=http://elasticsearch:9200
 

--- a/environments/includes/nginx.base.yml
+++ b/environments/includes/nginx.base.yml
@@ -10,6 +10,7 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-nginx.loadbalancer.server.port=80
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
     volumes:
       - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
     environment:

--- a/environments/includes/rabbitmq.base.yml
+++ b/environments/includes/rabbitmq.base.yml
@@ -8,6 +8,7 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-rabbitmq.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-rabbitmq.rule=Host(`rabbitmq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-rabbitmq.loadbalancer.server.port=15672
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
     volumes:
       - rabbitmq:/var/lib/rabbitmq
 

--- a/environments/includes/varnish.base.yml
+++ b/environments/includes/varnish.base.yml
@@ -4,6 +4,7 @@ services:
     labels:
       - traefik.enable=false
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=2
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
 
   varnish:
     hostname: "${WARDEN_ENV_NAME}-varnish"
@@ -17,3 +18,4 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.rule=
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-varnish.loadbalancer.server.port=80
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default

--- a/environments/magento2/magento2.base.yml
+++ b/environments/magento2/magento2.base.yml
@@ -15,6 +15,7 @@ services:
             && (Path(`/livereload.js`) || Path(`/livereload`))
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.service=${WARDEN_ENV_NAME}-livereload
       - traefik.http.services.${WARDEN_ENV_NAME}-livereload.loadbalancer.server.port=35729
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
     environment:
       - MAGE_DEBUG_SHOW_ARGS=1
 


### PR DESCRIPTION
My Traefik log was get clogged up with the following warnings whenever a `warden env stop/start/up/down` was happening:
```
Could not find network named 'warden' for container '/magento2_varnish_1'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." providerName=docker container=varnish-magento2-5e4efd55 serviceName=magento2-varnish
Could not find network named 'warden' for container '/magento2_php-fpm_1'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." providerName=docker container=php-fpm-magento2-5e4efd55 serviceName=magento2-php-fpm
Could not find network named 'warden' for container '/magento2_elasticsearch-hq_1'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." providerName=docker container=elasticsearch-hq-magento2-5e4efd55 serviceName=magento2-elasticsearch-hq
Could not find network named 'warden' for container '/magento2_elasticsearch_1'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." providerName=docker container=elasticsearch-magento2-5e4efd55 serviceName=magento2-elasticsearch
Could not find network named 'warden' for container '/magento2_rabbitmq_1'! Maybe you're missing the project's prefix in the label? Defaulting to first available network." providerName=docker container=rabbitmq-magento2-5e4efd55 serviceName=magento2-rabbitmq
```

With this change, my Traefik log is less chaotic :).