### PR TITLE
Updated environment default Elasticsearch version from 7.6 to 7.13

### DIFF
--- a/docs/environments/magento2.md
+++ b/docs/environments/magento2.md
@@ -32,7 +32,7 @@ The below example demonstrates the from-scratch setup of the Magento 2 applicati
 
         WARDEN_SYNC_IGNORE=
 
-        ELASTICSEARCH_VERSION=7.6
+        ELASTICSEARCH_VERSION=7.13
         MARIADB_VERSION=10.3
         NODE_VERSION=12
         COMPOSER_VERSION=1


### PR DESCRIPTION
7.6 does not run on M1 and 7.13 does.