### PR TITLE
Fix varnish version in images

### DIFF
--- a/images/varnish/4.1/Dockerfile
+++ b/images/varnish/4.1/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf upgrade -y \
 ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish41/script.rpm.sh
 RUN curl -s "${RPM_SCRIPT}" | bash \
     && dnf install -y epel-release \
+    && dnf module disable -y varnish \
     && dnf install -y varnish gettext \
     && dnf clean all \
     && rm -rf /var/cache/dnf

--- a/images/varnish/4.1/Dockerfile
+++ b/images/varnish/4.1/Dockerfile
@@ -1,16 +1,15 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:7
 
-RUN dnf upgrade -y \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+RUN yum upgrade -y \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 
 ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish41/script.rpm.sh
 RUN curl -s "${RPM_SCRIPT}" | bash \
-    && dnf install -y epel-release \
-    && dnf module disable -y varnish \
-    && dnf install -y varnish gettext \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+    && yum install -y epel-release \
+    && yum install -y varnish gettext \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 
 ENV VCL_CONFIG      /etc/varnish/default.vcl
 ENV CACHE_SIZE      256m

--- a/images/varnish/6.0/Dockerfile
+++ b/images/varnish/6.0/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf upgrade -y \
 ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish60lts/script.rpm.sh
 RUN curl -s "${RPM_SCRIPT}" | bash \
     && dnf install -y epel-release \
+    && dnf module disable -y varnish \
     && dnf install -y varnish gettext \
     && dnf clean all \
     && rm -rf /var/cache/dnf

--- a/images/varnish/6.4/Dockerfile
+++ b/images/varnish/6.4/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf upgrade -y \
 ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish64/script.rpm.sh
 RUN curl -s "${RPM_SCRIPT}" | bash \
     && dnf install -y epel-release \
+    && dnf module disable -y varnish \
     && dnf install -y varnish gettext \
     && dnf clean all \
     && rm -rf /var/cache/dnf

--- a/images/varnish/6.5/Dockerfile
+++ b/images/varnish/6.5/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf upgrade -y \
 ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish65/script.rpm.sh
 RUN curl -s "${RPM_SCRIPT}" | bash \
     && dnf install -y epel-release \
+    && dnf module disable -y varnish \
     && dnf install -y varnish gettext \
     && dnf clean all \
     && rm -rf /var/cache/dnf


### PR DESCRIPTION
See #480; this was a bug caused by Appstream pkg for varnish overriding the custom one from the Package Cloud repo with specific versions resulting in all the Varnish images having the default 4.0.x version from EL 8 rpms.

After these changes, the built images have the correct varnish versions once more:

```
$ docker run --rm -it wardenenv/varnish:6.5 varnishd -V
varnishd (varnish-6.5.2 revision e7233b0ad2639043341819d19a8d2e418e94ce1b)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2020 Varnish Software

$ docker run --rm -it wardenenv/varnish:6.4 varnishd -V
varnishd (varnish-6.4.0 revision 13f137934ec1cf14af66baf7896311115ee35598)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2020 Varnish Software AS

$ docker run --rm -it wardenenv/varnish:6.0 varnishd -V
varnishd (varnish-6.0.10 revision 9a7da4ff4c0c824af33e230740a11e99fdca23d9)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2021 Varnish Software

$ docker run --rm -it wardenenv/varnish:4.1 varnishd -V
varnishd (varnish-4.1.11 revision 61367ed17d08a9ef80a2d42dc84caef79cdeee7a)
Copyright (c) 2006 Verdens Gang AS
Copyright (c) 2006-2019 Varnish Software AS
```
