### PR TITLE
Varnish multi-arch builds

### DIFF
--- a/.github/workflows/docker-image-varnish.yml
+++ b/.github/workflows/docker-image-varnish.yml
@@ -1,18 +1,18 @@
 name: Docker Image Varnish
 on:
   schedule:
-  - cron: "0 6 1 * *"   # 6 AM UTC on 1st day of month
+    - cron: "0 6 1 * *"   # 6 AM UTC on 1st day of month
   push:
     paths:
-    - version
-    - images/.trigger
-    - images/varnish/**
+      - version
+      - images/.trigger
+      - images/varnish/**
     branches:
-    - develop
+      - develop
 jobs:
   varnish:
     name: Varnish
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -23,40 +23,40 @@ jobs:
             multiarch: 'false'
           - version: '6.4'
             multiarch: 'false'
-            
+    
     runs-on: ubuntu-latest
     steps:
-    
-    - uses: actions/checkout@v2
-    
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-      
-     - name: Login to DockerHub
-       uses: docker/login-action@v1
-       with:
-         username: ${{ secrets.DOCKER_USERNAME }}
-         password: ${{ secrets.DOCKER_PASSWORD }}
-      
-    - name: Build and push (amd64, arm64)
-      uses: docker/build-push-action@v2
-      if: ${{ matrix.multiarch == 'true' }}
-      with:
-        context: images/varnish/context
-        file: images/varnish/${{ matrix.version }}/Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: docker.io/wardenenv/varnish:${{ matrix.version }}
+      - uses: actions/checkout@v2
 
-    - name: Build and push (amd64 only)
-      uses: docker/build-push-action@v2
-      if: ${{ matrix.multiarch == 'false' }}
-      with:
-        context: images/varnish/context
-        file: images/varnish/${{ matrix.version }}/Dockerfile
-        platforms: linux/amd64
-        push: true
-        tags: docker.io/wardenenv/varnish:${{ matrix.version }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push (amd64, arm64)
+        uses: docker/build-push-action@v2
+        if: ${{ matrix.multiarch == 'true' }}
+        with:
+          context: images/varnish/context
+          file: images/varnish/${{ matrix.version }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: docker.io/wardenenv/varnish:${{ matrix.version }}
+
+      - name: Build and push (amd64 only)
+        uses: docker/build-push-action@v2
+        if: ${{ matrix.multiarch == 'false' }}
+        with:
+          context: images/varnish/context
+          file: images/varnish/${{ matrix.version }}/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: docker.io/wardenenv/varnish:${{ matrix.version }}

--- a/.github/workflows/docker-image-varnish.yml
+++ b/.github/workflows/docker-image-varnish.yml
@@ -12,11 +12,51 @@ on:
 jobs:
   varnish:
     name: Varnish
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['6.0', '6.5', '6.6', '7.0']
+        multiarch: ['true']
+        include:
+          - version: '4.1'
+            multiarch: 'false'
+          - version: '6.4'
+            multiarch: 'false'
+            
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"
-      env:
-        BUILD_GROUP: varnish
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - uses: actions/checkout@v2
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      
+     - name: Login to DockerHub
+       uses: docker/login-action@v1
+       with:
+         username: ${{ secrets.DOCKER_USERNAME }}
+         password: ${{ secrets.DOCKER_PASSWORD }}
+      
+    - name: Build and push (amd64, arm64)
+      uses: docker/build-push-action@v2
+      if: ${{ matrix.multiarch == 'true' }}
+      with:
+        context: images/varnish/context
+        file: images/varnish/${{ matrix.version }}/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: docker.io/wardenenv/varnish:${{ matrix.version }}
+
+    - name: Build and push (amd64 only)
+      uses: docker/build-push-action@v2
+      if: ${{ matrix.multiarch == 'false' }}
+      with:
+        context: images/varnish/context
+        file: images/varnish/${{ matrix.version }}/Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: docker.io/wardenenv/varnish:${{ matrix.version }}

--- a/images/varnish/6.6/Dockerfile
+++ b/images/varnish/6.6/Dockerfile
@@ -1,0 +1,29 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf upgrade -y \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish66/script.rpm.sh
+RUN curl -s "${RPM_SCRIPT}" | bash \
+    && dnf install -y epel-release \
+    && dnf module disable -y varnish \
+    && dnf install -y varnish gettext \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+ENV VCL_CONFIG      /etc/varnish/default.vcl
+ENV CACHE_SIZE      256m
+ENV VARNISHD_PARAMS -p default_ttl=3600 -p default_grace=3600 \
+    -p feature=+esi_ignore_https -p feature=+esi_disable_xml_check
+
+COPY default.vcl /etc/varnish/default.vcl.template
+
+ENV BACKEND_HOST    nginx
+ENV BACKEND_PORT    80
+ENV ACL_PURGE_HOST  0.0.0.0/0
+
+EXPOSE 	80
+CMD envsubst '${BACKEND_HOST} ${BACKEND_PORT} ${ACL_PURGE_HOST}' \
+        < /etc/varnish/default.vcl.template > /etc/varnish/default.vcl \
+    && varnishd -F -f $VCL_CONFIG -s malloc,$CACHE_SIZE $VARNISHD_PARAMS

--- a/images/varnish/7.0/Dockerfile
+++ b/images/varnish/7.0/Dockerfile
@@ -1,0 +1,29 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf upgrade -y \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+ARG RPM_SCRIPT=https://packagecloud.io/install/repositories/varnishcache/varnish70/script.rpm.sh
+RUN curl -s "${RPM_SCRIPT}" | bash \
+    && dnf install -y epel-release \
+    && dnf module disable -y varnish \
+    && dnf install -y varnish gettext \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+ENV VCL_CONFIG      /etc/varnish/default.vcl
+ENV CACHE_SIZE      256m
+ENV VARNISHD_PARAMS -p default_ttl=3600 -p default_grace=3600 \
+    -p feature=+esi_ignore_https -p feature=+esi_disable_xml_check
+
+COPY default.vcl /etc/varnish/default.vcl.template
+
+ENV BACKEND_HOST    nginx
+ENV BACKEND_PORT    80
+ENV ACL_PURGE_HOST  0.0.0.0/0
+
+EXPOSE 	80
+CMD envsubst '${BACKEND_HOST} ${BACKEND_PORT} ${ACL_PURGE_HOST}' \
+        < /etc/varnish/default.vcl.template > /etc/varnish/default.vcl \
+    && varnishd -F -f $VCL_CONFIG -s malloc,$CACHE_SIZE $VARNISHD_PARAMS


### PR DESCRIPTION
This PR adds ARM64 architecture builds for Varnish images

**Status:**
-  ❌ Varnish 4.1 image isn't supporting arm64 architecture as it's based on centos 7 that don't have arm64 support
- ✅ Varnish 6.0
- ❌ Varnish 6.4 image for which [we don't have arm64 packages](https://packagecloud.io/varnishcache/varnish64)
- ✅  Varnish 6.5 image
- ✅  Varnish 6.6 image (added in this PR)
- ✅  Varnish 7.0 image (added in this PR)

All images are currently available at  https://github.com/ihor-sviziev/warden/pkgs/container/varnish, they're built from the following commit: https://github.com/ihor-sviziev/warden/commit/727e086d3731f4cbda557ce3481d43a0d5b93f3d

Note: Marked with ❌ symbol images are old images and they won't support arm any time soon.