### PR TITLE
Elasticsearch multi-arch builds

### DIFF
--- a/.github/workflows/docker-image-elasticsearch.yml
+++ b/.github/workflows/docker-image-elasticsearch.yml
@@ -12,11 +12,47 @@ on:
 jobs:
   elasticsearch:
     name: Elasticsearch
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: '6.8'
+            multiarch: 'false'
+          - version: '7.13'
+            multiarch: 'true'
+
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - run: ./images/scripts/build.sh --push "${BUILD_GROUP}"
-      env:
-        BUILD_GROUP: elasticsearch
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push (amd64, arm64)
+        uses: docker/build-push-action@v2
+        if: ${{ matrix.multiarch == 'true' }}
+        with:
+          file: images/elasticsearch/${{ matrix.version }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: docker.io/wardenenv/elasticsearch:${{ matrix.version }}
+
+      - name: Build and push (amd64 only)
+        uses: docker/build-push-action@v2
+        if: ${{ matrix.multiarch == 'false' }}
+        with:
+          file: images/elasticsearch/${{ matrix.version }}/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: docker.io/wardenenv/elasticsearch:${{ matrix.version }}


### PR DESCRIPTION
This PR adds ARM64 architecture builds for Elasticsearch images
**Status:**
❌ Elasticsearch 6.8 doesn't support arm builds as base image is not optimized.
✅ Elasticsearch 7.13 does support arm builds

All images are currently available at https://github.com/ihor-sviziev/warden/pkgs/container/elasticsearch

Note: Marked with ❌ symbol images are old images and they won't support arm any time soon. 