### PR TITLE
Require docker compose 2.2.3 when compose v2 is active

### DIFF
--- a/bin/warden
+++ b/bin/warden
@@ -22,9 +22,16 @@ fi
 
 ## verify docker-compose meets version constraint
 DOCKER_COMPOSE_REQUIRE="1.25.0"
+DOCKER_COMPOSE_REQUIRE_V2="2.2.3"
 DOCKER_COMPOSE_VERSION="$(docker-compose --version | grep -oE '[0-9\.]+' | head -n1)"
 if ! test $(version ${DOCKER_COMPOSE_VERSION}) -ge $(version ${DOCKER_COMPOSE_REQUIRE}); then
   fatal "docker-compose version should be ${DOCKER_COMPOSE_REQUIRE} or higher (${DOCKER_COMPOSE_VERSION} installed)"
+fi
+
+if test $(version ${DOCKER_COMPOSE_VERSION}) -ge $(version "2.0.0") \
+  && ! test $(version ${DOCKER_COMPOSE_VERSION}) -ge $(version ${DOCKER_COMPOSE_REQUIRE_V2})
+then
+  fatal "docker-compose version should be ${DOCKER_COMPOSE_REQUIRE_V2} or higher (${DOCKER_COMPOSE_VERSION} installed)"
 fi
 
 ## define and export global shared directory paths


### PR DESCRIPTION
As noted in #423 compose v2 has seen some dramatic issues. This resolves #423 by enforcing a constraint of 2.2.3 or higher while still allowing continued use of v1 with existing constraint of 1.25.0 or greater, as there may still be compatibility issues due to upstream BC breaks and Linux users will still have v1 installed by default (v2 is now the default for Docker Desktop on macOS)