### PR TITLE
Fix gulp-sass 5 does not have a default Sass compiler error

### DIFF
--- a/homepage/gulpfile.js
+++ b/homepage/gulpfile.js
@@ -8,7 +8,7 @@ var gulp                    = require("gulp"),
     htmlmin                 = require("gulp-htmlmin"),
 
     // CSS plugins
-    sass                    = require("gulp-sass"),
+    sass                    = require('gulp-sass')(require('sass')),
     combineMediaQueries     = require("gulp-combine-mq"),
     autoprefixer            = require("gulp-autoprefixer"),
     cssmin                  = require("gulp-clean-css"),

--- a/homepage/package-lock.json
+++ b/homepage/package-lock.json
@@ -7909,6 +7909,25 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
         },
+        "sass": {
+            "version": "1.49.8",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.8.tgz",
+            "integrity": "sha512-NoGOjvDDOU9og9oAxhRnap71QaTjjlzrvLnKecUJ3GxhaQBrV6e7gPuSPF28u1OcVAArVojPAe4ZhOXwwC4tGw==",
+            "dev": true,
+            "requires": {
+                "chokidar": ">=3.0.0 <4.0.0",
+                "immutable": "^4.0.0",
+                "source-map-js": ">=0.6.2 <2.0.0"
+            },
+            "dependencies": {
+                "immutable": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+                    "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+                    "dev": true
+                }
+            }
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",

--- a/homepage/package.json
+++ b/homepage/package.json
@@ -16,6 +16,7 @@
         "gulp-util": "*",
         "gulp-watch": "*",
         "browser-sync": "*",
+        "sass": "*",
         "glob": "*"
     }
 }


### PR DESCRIPTION
10:43:38 PM: $ gulp build
10:43:40 PM: [04:43:40] Using gulpfile /opt/build/repo/homepage/gulpfile.js
10:43:40 PM: [04:43:40] Starting 'html'...
10:43:40 PM: [04:43:40] Starting 'images'...
10:43:40 PM: [04:43:40] Starting 'css'...
10:43:40 PM: Error in plugin "gulp-sass"
10:43:40 PM: Message:
10:43:40 PM: gulp-sass 5 does not have a default Sass compiler; please set one yourself.
10:43:40 PM: Both the `sass` and `node-sass` packages are permitted.
10:43:40 PM: For example, in your gulpfile:
10:43:40 PM:   var sass = require('gulp-sass')(require('sass'));