### PR TITLE
Get newest magerun version

### DIFF
--- a/images/php-fpm/magento2/Dockerfile
+++ b/images/php-fpm/magento2/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install -g grunt-cli gulp yarn
 RUN set -eux \
     && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
     && if (( ${PHP_VERSION} >= 72 )); \
-        then MAGERUN_PHAR_URL=https://files.magerun.net/n98-magerun2.phar; \
+        then MAGERUN_PHAR_URL=https://files.magerun.net/n98-magerun2-latest.phar; \
         else MAGERUN_PHAR_URL=https://files.magerun.net/n98-magerun2-3.2.0.phar; \
     fi \
     && mkdir -p /usr/local/bin \


### PR DESCRIPTION
This PR changes the `URL` so that the latest version of magerun will be downloaded. The current version present in the code is outdated and its listed under https://files.magerun.net/old_versions.php, which was last updated on `2022-05-23 12:05`