### PR TITLE
fix(phpmyadmin): no such file or directory for phpmyadmin override

### DIFF
--- a/utils/core.sh
+++ b/utils/core.sh
@@ -64,6 +64,7 @@ function regeneratePMAConfig() {
   if [[ "${WARDEN_PHPMYADMIN_ENABLE}" == 1 ]]; then
     echo "Regenerating phpMyAdmin configuration..."
     pma_config_file="${WARDEN_HOME_DIR}/etc/phpmyadmin/config.user.inc.php"
+    mkdir -p "$(dirname "$pma_config_file")"
     {
       echo "<?php"
       echo "\$i = 1;"


### PR DESCRIPTION
**Check List**
- [ ] Is there an existing issue that covers this? (link it here, if so)
- [x] Is there an entry in the CHANGELOG.md file?

**Describe the bug**
phpmyadmin config generation fails if the config directory does not already exist. 

**To Reproduce**
Steps to reproduce the behavior:
1. Checkout current main branch
2. Make sure the config directory does not already exist `mv ~/.warden/etc/phpmyadmin{,.bak}`
3. Run `warden env up`

**Expected behavior**
phpmyadmin config to generate sucessfully, and not display any errors 

**Screenshots**
<img width="1715" height="598" alt="image" src="https://github.com/user-attachments/assets/adec8ff6-045a-4af3-8389-b9dfa71e2da2" />