### PR TITLE
[WIP] fix(php-fpm): rework php-fpm backend selection

### DIFF
--- a/environments/includes/nginx.base.yml
+++ b/environments/includes/nginx.base.yml
@@ -14,3 +14,6 @@ services:
       - .${WARDEN_WEB_ROOT:-}/:/var/www/html:cached
     environment:
       - XDEBUG_CONNECT_BACK_HOST=${XDEBUG_CONNECT_BACK_HOST:-''}
+      - WARDEN_BLACKFIRE=${WARDEN_BLACKFIRE:-'0'}
+      - PHP_XDEBUG_3=${PHP_XDEBUG_3:-'0'}
+      - WARDEN_PHP_SPX=${WARDEN_PHP_SPX:-'0'}


### PR DESCRIPTION
Related to pull request within the images repository - https://github.com/wardenenv/images/pull/63

Handle passing the enabled status of various debug containers (SPX, XDEBUG, Blackfire) to the Nginx container. Which allows us to choose the relevant fastcgi backend based on what containers are available.

Should help prevent 502 errors when disabling SPX/XDEBUG, but still having the cookies present. 
Such as in the following issues: https://github.com/wardenenv/warden/pull/820#issuecomment-2490627675 https://github.com/wardenenv/warden/issues/822