### PR TITLE
fix(core): alert user to missing global services

### DIFF
--- a/utils/core.sh
+++ b/utils/core.sh
@@ -44,6 +44,10 @@ function assertDockerRunning {
 ## methods to peer global services requiring network connectivity with project networks
 function connectPeeredServices {
   for svc in ${DOCKER_PEERED_SERVICES[@]}; do
+    if [ ! "$(docker ps -a -q -f name=${svc})" ]; then
+        fatal "Missing Global Service: ${svc}. Run 'warden svc up' and try again."
+    fi
+
     echo "Connecting ${svc} to $1 network"
     (docker network connect "$1" ${svc} 2>&1| grep -v 'already exists in network') || true
   done


### PR DESCRIPTION
<!-- [BUG] Feel free to delete everything between the bug tags if not a bug -->
**Check List**
- [ ] Is there an existing issue that covers this? (link it here, if so)
- [ ] Is there an entry in the CHANGELOG.md file?

**Describe the bug**
If a core service is missing, you get a generic no such container error message, and the application will still attempt to run. 

**To Reproduce**
Steps to reproduce the behavior:
1. Checkout latest release `0.15.0`
2. Start warden `warden svc up`
3. Checkout latest main branch
4. Start a project `warden env up`

> Note: If you have previously been using latest dev branch, you may need to fully remove the phpmyadmin container. 
`docker rm -f $(docker ps -a -q -f name=phpmyadmin)`

**Expected behavior**
Fatal error to occur to indicate to the user, that the core is in a unhealthy/outdated state.

**Screenshots**
Before:
<img width="700" height="212" alt="Screenshot 2025-10-12 at 23 50 46" src="https://github.com/user-attachments/assets/8dec023e-753b-4e83-9569-20ed972158cc" />

After:
<img width="955" height="156" alt="image" src="https://github.com/user-attachments/assets/933a4370-0fe6-4ff9-bb37-2804f24c4187" />
