### PR TITLE
Update default Traefik version to 2.11 (from 2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 **Bug Fixes:**
 * System-level SSL certificates are no longer overwritten ([#812](https://github.com/wardenenv/warden/pull/812) by @SamJUK)
 * Portainer service domain default fix ([#837] by @hardyjohnson credit to: @manuelcanepa)
+* Updated default Traefik version to 2.11 (from 2.2) to fix compatibility with newer Docker versions ([#896] by @mattijv)
 
 ## Version [0.15.0](https://github.com/wardenenv/warden/tree/0.15.0) (2024-11-04)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   traefik:
     container_name: traefik
-    image: traefik:${TRAEFIK_VERSION:-2.2}
+    image: traefik:${TRAEFIK_VERSION:-2.11}
     ports:
       - "${TRAEFIK_LISTEN:-127.0.0.1}:80:80"     # The HTTP port
       - "${TRAEFIK_LISTEN:-127.0.0.1}:443:443"   # The HTTPS port


### PR DESCRIPTION
The 29.0.0 version of Docker broke the version of Traefik used in Warden (see https://github.com/traefik/traefik/issues/12253).

This commit changes the default Traefik version to 2.11 which should be compatible with newer versions of Docker (Traefik 2.11.31 is compatible, to be precise).

Fixes https://github.com/wardenenv/warden/issues/896.

<!-- [BUG] Feel free to delete everything between the bug tags if not a bug -->
**Check List**
- [x] Is there an existing issue that covers this? (link it here, if so)
- [X] Is there an entry in the CHANGELOG.md file?

<!-- [/BUG] -->