### PR TITLE
Add shell autocompletion support

### DIFF
--- a/commands/install.cmd
+++ b/commands/install.cmd
@@ -86,6 +86,30 @@ fi
 ## append settings for tunnel.warden.test in /etc/ssh/ssh_config
 installSshConfig
 
+## install shell completions
+WARDEN_COMPLETIONS_DIR="${WARDEN_HOME_DIR}/completions"
+mkdir -p "${WARDEN_COMPLETIONS_DIR}"
+
+# symlink completion files into ~/.warden/completions/
+ln -sf "${WARDEN_DIR}/completions/warden.bash" "${WARDEN_COMPLETIONS_DIR}/warden.bash"
+ln -sf "${WARDEN_DIR}/completions/_warden" "${WARDEN_COMPLETIONS_DIR}/_warden"
+
+# Bash: source completion from ~/.bashrc if not already present
+BASHRC="${HOME}/.bashrc"
+if [[ -f "${BASHRC}" ]] && ! grep -q 'warden/completions/warden.bash' "${BASHRC}" 2>/dev/null; then
+  echo "==> Adding warden bash completion to ${BASHRC}"
+  printf '\n# Warden CLI bash completion\n[ -f "%s/warden.bash" ] && source "%s/warden.bash"\n' \
+    "${WARDEN_COMPLETIONS_DIR}" "${WARDEN_COMPLETIONS_DIR}" >> "${BASHRC}"
+fi
+
+# Zsh: add fpath entry to ~/.zshrc if not already present
+ZSHRC="${HOME}/.zshrc"
+if [[ -f "${ZSHRC}" || "$OSTYPE" == "darwin"* ]] && ! grep -q 'warden/completions' "${ZSHRC}" 2>/dev/null; then
+  echo "==> Adding warden zsh completion to ${ZSHRC}"
+  printf '\n# Warden CLI zsh completion\nfpath=("%s" $fpath)\nautoload -Uz compinit && compinit\n' \
+    "${WARDEN_COMPLETIONS_DIR}" >> "${ZSHRC}"
+fi
+
 ## Add optional Warden configuration file
 if [[ ! -f "${WARDEN_HOME_DIR}/.env" ]]; then
 	cat >> "${WARDEN_HOME_DIR}/.env" <<-EOT

--- a/completions/_warden
+++ b/completions/_warden
@@ -47,9 +47,21 @@ _warden() {
             fi
             ;;
         env|svc)
+            # These commands delegate to docker compose
             if (( CURRENT == 3 )); then
-                local -a compose_cmds=(up down start stop restart ps logs exec run build pull config)
+                local -a compose_cmds
+                compose_cmds=(${(f)"$(docker compose --help 2>/dev/null | awk '/^  [a-z]/{print $1}')"})
+                if (( ${#compose_cmds} == 0 )); then
+                    compose_cmds=(up down start stop restart ps logs exec run build pull config)
+                fi
                 _describe 'compose subcommand' compose_cmds
+            elif (( CURRENT > 3 )); then
+                local subcmd="${words[3]}"
+                local -a opts
+                opts=(${(f)"$(docker compose ${subcmd} --help 2>/dev/null | grep -oE '  --[a-z][-a-z]*' | awk '{print $1}' | sort -u)"})
+                if (( ${#opts} )); then
+                    _describe 'option' opts
+                fi
             fi
             ;;
         env-init)

--- a/completions/_warden
+++ b/completions/_warden
@@ -1,0 +1,72 @@
+#compdef warden
+# Zsh completion for warden
+
+_warden() {
+    local warden_bin warden_dir
+    warden_bin="$(command -v warden 2>/dev/null)"
+    warden_dir=""
+    if [[ -n "${warden_bin}" ]]; then
+        local real_bin
+        real_bin="$(readlink "${warden_bin}" 2>/dev/null || echo "${warden_bin}")"
+        warden_dir="$(cd "$(dirname "${real_bin}")/.." 2>/dev/null && pwd)"
+    fi
+
+    local -a commands
+    if [[ -n "${warden_dir}" && -d "${warden_dir}/commands" ]]; then
+        commands=(${(f)"$(ls "${warden_dir}/commands/"*.cmd 2>/dev/null \
+            | xargs -I{} basename {} .cmd \
+            | grep -v usage)"})
+    fi
+    if (( ${#commands} == 0 )); then
+        commands=(blackfire db debug doctor env env-init install redis shell sign-certificate spx status svc sync valkey version vnc)
+    fi
+
+    local -a global_opts
+    global_opts=('-h[Show help]' '--help[Show help]' '-v[Enable verbose output]' '--verbose[Enable verbose output]')
+
+    # Top-level: complete command name
+    if (( CURRENT == 2 )); then
+        _describe 'warden command' commands
+        _arguments -s ${global_opts}
+        return
+    fi
+
+    local cmd="${words[2]}"
+
+    case "${cmd}" in
+        db)
+            if (( CURRENT == 3 )); then
+                local -a db_cmds=(connect import dump upgrade)
+                _describe 'db subcommand' db_cmds
+            fi
+            ;;
+        sync)
+            if (( CURRENT == 3 )); then
+                local -a sync_cmds=(start stop list flush monitor pause reset resume)
+                _describe 'sync subcommand' sync_cmds
+            fi
+            ;;
+        env|svc)
+            if (( CURRENT == 3 )); then
+                local -a compose_cmds=(up down start stop restart ps logs exec run build pull config)
+                _describe 'compose subcommand' compose_cmds
+            fi
+            ;;
+        env-init)
+            if (( CURRENT == 4 )); then
+                local -a env_types
+                if [[ -n "${warden_dir}" && -d "${warden_dir}/environments" ]]; then
+                    env_types=(${(f)"$(ls -d "${warden_dir}/environments/"*/ 2>/dev/null \
+                        | xargs -I{} basename {} \
+                        | grep -v includes)"})
+                fi
+                if (( ${#env_types} == 0 )); then
+                    env_types=(cakephp drupal laravel local magento1 magento2 shopware symfony wordpress)
+                fi
+                _describe 'environment type' env_types
+            fi
+            ;;
+    esac
+}
+
+_warden "$@"

--- a/completions/warden.bash
+++ b/completions/warden.bash
@@ -46,8 +46,21 @@ _warden() {
             fi
             ;;
         env|svc)
+            # These commands delegate to docker compose
             if [[ ${cword} -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "up down start stop restart ps logs exec run build pull config" -- "${cur}"))
+                local compose_cmds
+                compose_cmds="$(docker compose --help 2>/dev/null | awk '/^  [a-z]/{print $1}' | tr '\n' ' ')"
+                if [[ -z "${compose_cmds}" ]]; then
+                    compose_cmds="up down start stop restart ps logs exec run build pull config"
+                fi
+                COMPREPLY=($(compgen -W "${compose_cmds}" -- "${cur}"))
+            elif [[ ${cword} -ge 3 ]]; then
+                local subcmd="${words[2]}"
+                local opts
+                opts="$(docker compose "${subcmd}" --help 2>/dev/null | grep -oE '  --[a-z][-a-z]*' | awk '{print $1}' | sort -u | tr '\n' ' ')"
+                if [[ -n "${opts}" ]]; then
+                    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+                fi
             fi
             ;;
         env-init)

--- a/completions/warden.bash
+++ b/completions/warden.bash
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Bash completion for warden
+
+_warden() {
+    local cur prev words cword
+    _init_completion || return
+
+    # Resolve WARDEN_DIR from the warden binary location
+    local warden_bin
+    warden_bin="$(command -v warden 2>/dev/null)"
+    local warden_dir=""
+    if [[ -n "${warden_bin}" ]]; then
+        local real_bin
+        real_bin="$(readlink "${warden_bin}" 2>/dev/null || echo "${warden_bin}")"
+        warden_dir="$(cd "$(dirname "${real_bin}")/.." 2>/dev/null && pwd)"
+    fi
+
+    local global_opts="-h --help -v --verbose"
+
+    # Top-level: complete commands
+    if [[ ${cword} -eq 1 ]]; then
+        local commands=""
+        if [[ -n "${warden_dir}" && -d "${warden_dir}/commands" ]]; then
+            commands="$(ls "${warden_dir}/commands/"*.cmd 2>/dev/null \
+                | xargs -I{} basename {} .cmd \
+                | grep -v usage)"
+        fi
+        if [[ -z "${commands}" ]]; then
+            commands="blackfire db debug doctor env env-init install redis shell sign-certificate spx status svc sync valkey version vnc"
+        fi
+        COMPREPLY=($(compgen -W "${commands} ${global_opts}" -- "${cur}"))
+        return
+    fi
+
+    local cmd="${words[1]}"
+
+    case "${cmd}" in
+        db)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "connect import dump upgrade" -- "${cur}"))
+            fi
+            ;;
+        sync)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "start stop list flush monitor pause reset resume" -- "${cur}"))
+            fi
+            ;;
+        env|svc)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "up down start stop restart ps logs exec run build pull config" -- "${cur}"))
+            fi
+            ;;
+        env-init)
+            if [[ ${cword} -eq 3 ]]; then
+                local env_types=""
+                if [[ -n "${warden_dir}" && -d "${warden_dir}/environments" ]]; then
+                    env_types="$(ls -d "${warden_dir}/environments/"*/ 2>/dev/null \
+                        | xargs -I{} basename {} \
+                        | grep -v includes)"
+                fi
+                if [[ -z "${env_types}" ]]; then
+                    env_types="cakephp drupal laravel local magento1 magento2 shopware symfony wordpress"
+                fi
+                COMPREPLY=($(compgen -W "${env_types}" -- "${cur}"))
+            fi
+            ;;
+    esac
+}
+
+complete -F _warden warden


### PR DESCRIPTION
<!-- [FEATURE] Feel free to delete everything between the [FEATURE] tags if not a new feature -->
**Check List**
- [ ] Matching PR in the documentation repo (replace text with link when it exists)
- [ ] Entry in CHANGELOG.md

**Is your feature request related to a problem? Please describe.**  
 Warden CLI has no shell autocompletion, so users must remember all commands, or create aliases manually, which slows down the workflow.

**Describe the solution you've submitted**  
Added bash and zsh completion scripts that dynamically discover available commands from commands/*.cmd files. Completions cover top-level commands, subcommands for db, sync, env, svc, and environment types for env-init. The warden install command now automatically sets up completions by symlinking scripts into ~/.warden/completions/ and updating shell rc files.

**Describe alternatives you've considered**  
Static hardcoded command lists - rejected in favor of dynamic discovery.

**Additional context**  
Tested on macOS with zsh and bash. Completions fall back to a hardcoded list if the commands directory is unavailable.

**Note:** top-level commands are discovered dynamically from *.cmd files, but subcommands (e.g. db connect|import|dump|upgrade, sync start|stop|list|...) are hardcoded in the completion scripts because they are
  defined inside the command files themselves, not as separate discoverable entities. This means the completion scripts will need to be updated manually whenever new subcommands are added to existing commands.
<!-- [/FEATURE] -->