### PR TITLE
[907] Fix sign-certificate WARDEN_DOCKER_SOCK error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)
+* Fix WARDEN_DOCKER_SOCK error running `warden sign-certificate` ([#907](https://github.com/wardenenv/warden/issues/907) by @bap14)
 
 ## Version [0.16.0](https://github.com/wardenenv/warden/tree/0.16.0) (2026-02-12)
 

--- a/commands/sign-certificate.cmd
+++ b/commands/sign-certificate.cmd
@@ -51,7 +51,7 @@ openssl x509 -req -days 365 -sha256 -extensions v3_req            \
   -in "${WARDEN_SSL_DIR}/certs/${CERTIFICATE_NAME}.csr.pem"       \
   -out "${WARDEN_SSL_DIR}/certs/${CERTIFICATE_NAME}.crt.pem" 
 
-if [[ "$(cd "${WARDEN_HOME_DIR}" && ${DOCKER_COMPOSE_COMMAND} -p warden -f "${WARDEN_DIR}/docker/docker-compose.yml" ps -q traefik)" ]]
+if [[ "$(${WARDEN_BIN} svc ps -q traefik 2>/dev/null)" ]]
 then
   echo "==> Updating traefik"
   "$WARDEN_BIN" svc up traefik


### PR DESCRIPTION
**Check List**
- [x] Is there an existing issue that covers this? [#907 sign-certificate](https://github.com/wardenenv/warden/issues/907)
- [x] Is there an entry in the CHANGELOG.md file? Yes

**Describe the bug**
Running `sign-certificate` command emits an error about `WARDEN_DOCKER_SOCK` not being set, defaulting to a blank string, resulting in an invalid docker command structure `-v :/var/run/docker.sock`.

**To Reproduce**
Steps to reproduce the behavior:
1. Be running warden 0.16.0
2. Run `warden sign-certificate <domain_name>`
4. See error

**Expected behavior**
A new certificate is generated and core services restarted to pick up the change.

**Screenshots**


**Additional context**
