### PR TITLE
feat: add Quick Tunnel support for instant public URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## UNRELEASED
 [All Commits](https://github.com/wardenenv/warden/compare/0.16.0..main)
 
+**Big Changes:**
+* Add Cloudflare Tunnel integration for exposing local projects to the public internet via `warden cf` commands ([#XX](https://github.com/wardenenv/warden/pull/XX) by @lbajsarowicz)
+
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)
 * Fix WARDEN_DOCKER_SOCK error running `warden sign-certificate` ([#907](https://github.com/wardenenv/warden/issues/907) by @bap14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [All Commits](https://github.com/wardenenv/warden/compare/0.16.0..main)
 
 **Big Changes:**
-* Add Cloudflare Tunnel integration for exposing local projects to the public internet via `warden cf` commands ([#XX](https://github.com/wardenenv/warden/pull/XX) by @lbajsarowicz)
+* Add Cloudflare Tunnel integration for exposing local projects to the public internet via `warden cf` commands ([#923](https://github.com/wardenenv/warden/pull/923) by @lbajsarowicz)
 
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Big Changes:**
 * Add Cloudflare Tunnel integration for exposing local projects to the public internet via `warden cf` commands ([#923](https://github.com/wardenenv/warden/pull/923) by @lbajsarowicz)
+* Add Quick Tunnel support for instant public URLs without custom domains (`WARDEN_QUICK_TUNNEL=1`) (by @lbajsarowicz)
 
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)

--- a/commands/cf.cmd
+++ b/commands/cf.cmd
@@ -79,7 +79,7 @@ case "${WARDEN_PARAMS[0]}" in
         fi
 
         if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
-            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env" | tr -d '\r')"
         fi
 
         if [[ -z "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
@@ -113,7 +113,7 @@ case "${WARDEN_PARAMS[0]}" in
         echo ""
         ## show tunnel ID
         if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
-            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env" | tr -d '\r')"
         fi
 
         if [[ -n "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
@@ -139,7 +139,7 @@ case "${WARDEN_PARAMS[0]}" in
         ;;
     update)
         if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
-            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env" | tr -d '\r')"
         fi
 
         if [[ -z "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
@@ -152,7 +152,7 @@ case "${WARDEN_PARAMS[0]}" in
     logout)
         ## check if tunnel exists and warn user to delete it first
         if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
-            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env" | tr -d '\r')"
         fi
         if [[ -n "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
             warning "A tunnel is still configured (ID: ${WARDEN_CLOUDFLARED_TUNNEL_ID})."

--- a/commands/cf.cmd
+++ b/commands/cf.cmd
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+source "${WARDEN_DIR}/utils/install.sh"
+assertDockerRunning
+
+CLOUDFLARED_DIR="${WARDEN_HOME_DIR}/etc/cloudflared"
+
+## load image repository from global config
+if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+    eval "$(grep "^WARDEN_IMAGE_REPOSITORY" "${WARDEN_HOME_DIR}/.env")"
+fi
+CLOUDFLARED_IMAGE="${WARDEN_IMAGE_REPOSITORY:-docker.io/wardenenv}/cloudflared:latest"
+
+if (( ${#WARDEN_PARAMS[@]} == 0 )) || [[ "${WARDEN_PARAMS[0]}" == "help" ]]; then
+  $WARDEN_BIN cf --help || exit $? && exit $?
+fi
+
+## allow return codes from sub-process to bubble up normally
+trap '' ERR
+
+case "${WARDEN_PARAMS[0]}" in
+    login)
+        mkdir -p "${CLOUDFLARED_DIR}"
+        echo "Opening browser for Cloudflare authentication..."
+        docker run --rm -it \
+            -v "${CLOUDFLARED_DIR}:/home/nonroot/.cloudflared" \
+            "${CLOUDFLARED_IMAGE}" \
+            tunnel login
+        if [[ -f "${CLOUDFLARED_DIR}/cert.pem" ]]; then
+            echo "Login successful. cert.pem saved to ${CLOUDFLARED_DIR}/"
+            echo "Next step: run 'warden cf create' to create a tunnel."
+        else
+            error "Login failed. No cert.pem found."
+            exit 1
+        fi
+        ;;
+    create)
+        if [[ ! -f "${CLOUDFLARED_DIR}/cert.pem" ]]; then
+            fatal "Not authenticated. Run 'warden cf login' first."
+        fi
+
+        TUNNEL_NAME="${WARDEN_PARAMS[1]:-warden}"
+        echo "Creating tunnel '${TUNNEL_NAME}'..."
+
+        CREATE_OUTPUT=$(docker run --rm \
+            -v "${CLOUDFLARED_DIR}:/home/nonroot/.cloudflared" \
+            "${CLOUDFLARED_IMAGE}" \
+            tunnel create "${TUNNEL_NAME}" 2>&1)
+
+        echo "${CREATE_OUTPUT}"
+
+        ## extract tunnel UUID from output (format: "Created tunnel <name> with id <uuid>")
+        TUNNEL_ID=$(echo "${CREATE_OUTPUT}" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+
+        if [[ -z "${TUNNEL_ID}" ]]; then
+            fatal "Failed to extract tunnel ID from output."
+        fi
+
+        ## write tunnel ID to global config
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]] && grep -q "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env"; then
+            sed -i.bak "s/^WARDEN_CLOUDFLARED_TUNNEL_ID=.*/WARDEN_CLOUDFLARED_TUNNEL_ID=${TUNNEL_ID}/" "${WARDEN_HOME_DIR}/.env"
+            rm -f "${WARDEN_HOME_DIR}/.env.bak"
+        else
+            echo "WARDEN_CLOUDFLARED_TUNNEL_ID=${TUNNEL_ID}" >> "${WARDEN_HOME_DIR}/.env"
+        fi
+
+        ## generate initial config
+        export WARDEN_CLOUDFLARED_TUNNEL_ID="${TUNNEL_ID}"
+        regenerateCloudflaredConfig
+
+        echo ""
+        echo "Tunnel '${TUNNEL_NAME}' created with ID: ${TUNNEL_ID}"
+        echo "Run 'warden svc up' to start the tunnel."
+        ;;
+    delete)
+        if [[ ! -f "${CLOUDFLARED_DIR}/cert.pem" ]]; then
+            fatal "Not authenticated. Run 'warden cf login' first."
+        fi
+
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+        fi
+
+        if [[ -z "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
+            fatal "No tunnel configured. Nothing to delete."
+        fi
+
+        echo "Deleting tunnel ${WARDEN_CLOUDFLARED_TUNNEL_ID}..."
+
+        ## stop cloudflared container first if running
+        docker stop cloudflared 2>/dev/null || true
+
+        docker run --rm \
+            -v "${CLOUDFLARED_DIR}:/home/nonroot/.cloudflared" \
+            "${CLOUDFLARED_IMAGE}" \
+            tunnel delete "${WARDEN_CLOUDFLARED_TUNNEL_ID}" || true
+
+        ## remove tunnel ID from global config
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+            sed -i.bak '/^WARDEN_CLOUDFLARED_TUNNEL_ID/d' "${WARDEN_HOME_DIR}/.env"
+            rm -f "${WARDEN_HOME_DIR}/.env.bak"
+        fi
+
+        ## remove credentials (but keep cert.pem for future tunnel creation)
+        rm -f "${CLOUDFLARED_DIR}/${WARDEN_CLOUDFLARED_TUNNEL_ID}.json"
+        rm -f "${CLOUDFLARED_DIR}/credentials.json"
+        rm -f "${CLOUDFLARED_DIR}/config.yml"
+
+        echo "Tunnel deleted. cert.pem preserved for future use."
+        ;;
+    status)
+        echo ""
+        ## show tunnel ID
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+        fi
+
+        if [[ -n "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
+            echo "Tunnel ID: ${WARDEN_CLOUDFLARED_TUNNEL_ID}"
+        else
+            echo "Tunnel ID: (not configured)"
+        fi
+
+        ## show container status
+        CONTAINER_STATUS=$(docker inspect --format '{{.State.Status}}' cloudflared 2>/dev/null || echo "not running")
+        echo "Container:  ${CONTAINER_STATUS}"
+
+        ## show connected domains
+        echo ""
+        echo "Connected domains:"
+        DOMAINS=$(docker ps --filter "label=dev.warden.cf.domain" --format '  {{.Label "dev.warden.cf.domain"}} ({{.Names}})' 2>/dev/null)
+        if [[ -n "${DOMAINS}" ]]; then
+            echo "${DOMAINS}"
+        else
+            echo "  (none)"
+        fi
+        echo ""
+        ;;
+    update)
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+        fi
+
+        if [[ -z "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
+            fatal "No tunnel configured. Run 'warden cf create' first."
+        fi
+
+        regenerateCloudflaredConfig
+        echo "Cloudflared configuration regenerated and container restarted."
+        ;;
+    logout)
+        ## check if tunnel exists and warn user to delete it first
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+            eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+        fi
+        if [[ -n "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
+            warning "A tunnel is still configured (ID: ${WARDEN_CLOUDFLARED_TUNNEL_ID})."
+            warning "Run 'warden cf delete' first to remove it from Cloudflare,"
+            warning "or the tunnel will become orphaned."
+            echo ""
+            read -p "Continue with logout anyway? [y/N] " confirm
+            [[ "${confirm}" != [yY]* ]] && exit 0
+        fi
+
+        echo "Cleaning up cloudflared configuration..."
+
+        ## stop container if running
+        docker stop cloudflared 2>/dev/null || true
+
+        ## remove tunnel ID from global config
+        if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+            sed -i.bak '/^WARDEN_CLOUDFLARED_TUNNEL_ID/d' "${WARDEN_HOME_DIR}/.env"
+            rm -f "${WARDEN_HOME_DIR}/.env.bak"
+        fi
+
+        ## remove all cloudflared files
+        rm -rf "${CLOUDFLARED_DIR}"
+
+        echo "Cloudflared configuration removed."
+        ;;
+    *)
+        fatal "Unknown subcommand '${WARDEN_PARAMS[0]}'. Run 'warden cf help' for usage."
+        ;;
+esac

--- a/commands/cf.cmd
+++ b/commands/cf.cmd
@@ -51,6 +51,7 @@ case "${WARDEN_PARAMS[0]}" in
         echo "${CREATE_OUTPUT}"
 
         ## extract tunnel UUID from output (format: "Created tunnel <name> with id <uuid>")
+        ## UUID is [0-9a-f-] only, which is safe for use in sed substitution below
         TUNNEL_ID=$(echo "${CREATE_OUTPUT}" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
 
         if [[ -z "${TUNNEL_ID}" ]]; then
@@ -65,8 +66,7 @@ case "${WARDEN_PARAMS[0]}" in
             echo "WARDEN_CLOUDFLARED_TUNNEL_ID=${TUNNEL_ID}" >> "${WARDEN_HOME_DIR}/.env"
         fi
 
-        ## generate initial config
-        export WARDEN_CLOUDFLARED_TUNNEL_ID="${TUNNEL_ID}"
+        ## generate initial config (reads TUNNEL_ID from ~/.warden/.env written above)
         regenerateCloudflaredConfig
 
         echo ""

--- a/commands/cf.cmd
+++ b/commands/cf.cmd
@@ -179,6 +179,37 @@ case "${WARDEN_PARAMS[0]}" in
 
         echo "Cloudflared configuration removed."
         ;;
+    quick)
+        WARDEN_ENV_PATH="$(locateEnvPath 2>/dev/null)" || true
+
+        if [[ -z "${WARDEN_ENV_PATH:-}" ]]; then
+            fatal "Not in a Warden environment directory. Navigate to a project with WARDEN_QUICK_TUNNEL=1."
+        fi
+
+        source "${WARDEN_DIR}/utils/env.sh"
+        loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
+
+        if [[ ${WARDEN_QUICK_TUNNEL:-0} -ne 1 ]]; then
+            fatal "WARDEN_QUICK_TUNNEL is not enabled for this project. Add WARDEN_QUICK_TUNNEL=1 to your .env file."
+        fi
+
+        ## extract the quick tunnel URL from container logs
+        QUICK_URL=$(${DOCKER_COMPOSE_COMMAND} \
+            --project-directory "${WARDEN_ENV_PATH}" -p "${WARDEN_ENV_NAME}" \
+            logs quick-tunnel 2>/dev/null | grep -oE 'https://[a-zA-Z0-9-]+\.trycloudflare\.com' | tail -1)
+
+        if [[ -n "${QUICK_URL}" ]]; then
+            echo ""
+            echo "Quick Tunnel URL: ${QUICK_URL}"
+            echo ""
+            echo "This URL is temporary and changes when the container restarts."
+        else
+            echo ""
+            echo "Quick Tunnel URL not found yet."
+            echo "The container may still be starting. Try:"
+            echo "  warden env logs quick-tunnel"
+        fi
+        ;;
     *)
         fatal "Unknown subcommand '${WARDEN_PARAMS[0]}'. Run 'warden cf help' for usage."
         ;;

--- a/commands/cf.help
+++ b/commands/cf.help
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+WARDEN_USAGE=$(cat <<EOF
+\033[33mUsage:\033[0m
+  cf <subcommand>
+
+\033[33mSubcommands:\033[0m
+  login             Authenticate with Cloudflare (opens browser)
+  create [name]     Create a new tunnel (default name: warden)
+  delete            Delete the tunnel from Cloudflare
+  status            Show tunnel and connected domains
+  update            Regenerate cloudflared config and restart
+  logout            Remove all cloudflared credentials and config
+
+\033[33mOptions:\033[0m
+  -h, --help        Display this help menu
+
+\033[33mDescription:\033[0m
+  Manages Cloudflare Tunnel integration for exposing local projects
+  to the public internet. Projects opt-in by setting TRAEFIK_PUBLIC_DOMAIN
+  in their .env file.
+
+\033[33mSetup:\033[0m
+  1. warden cf login          # Authenticate with Cloudflare
+  2. warden cf create         # Create tunnel
+  3. warden svc up            # Start global services (includes cloudflared)
+  4. Set TRAEFIK_PUBLIC_DOMAIN in project .env
+  5. warden env up            # Start project (config auto-generated)
+EOF
+)

--- a/commands/cf.help
+++ b/commands/cf.help
@@ -12,6 +12,7 @@ WARDEN_USAGE=$(cat <<EOF
   status            Show tunnel and connected domains
   update            Regenerate cloudflared config and restart
   logout            Remove all cloudflared credentials and config
+  quick             Show the Quick Tunnel URL for current project
 
 \033[33mOptions:\033[0m
   -h, --help        Display this help menu
@@ -27,5 +28,10 @@ WARDEN_USAGE=$(cat <<EOF
   3. warden svc up            # Start global services (includes cloudflared)
   4. Set TRAEFIK_PUBLIC_DOMAIN in project .env
   5. warden env up            # Start project (config auto-generated)
+
+\033[33mQuick Tunnel (no setup needed):\033[0m
+  1. Add WARDEN_QUICK_TUNNEL=1 to project .env
+  2. warden env up            # Starts quick tunnel container
+  3. warden cf quick          # Shows the random public URL
 EOF
 )

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -88,6 +88,9 @@ fi
 [[ ${WARDEN_NGINX} -eq 1 ]] \
     && appendEnvPartialIfExists "nginx"
 
+[[ ${WARDEN_NGINX} -eq 1 ]] && [[ -n "${TRAEFIK_PUBLIC_DOMAIN:-}" ]] \
+    && appendEnvPartialIfExists "nginx-public"
+
 [[ ${WARDEN_DB} -eq 1 ]] \
     && appendEnvPartialIfExists "db"
 

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -167,6 +167,7 @@ if [[ "${WARDEN_PARAMS[0]}" == "down" ]]; then
 
     ## regenerate PMA config on each env changing
     regeneratePMAConfig
+    regenerateCloudflaredConfig
 fi
 
 ## connect peered service containers to environment network
@@ -189,6 +190,7 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
 
     ## regenerate PMA config on each env changing
     regeneratePMAConfig
+    regenerateCloudflaredConfig
 fi
 
 ## lookup address of traefik container on environment network
@@ -232,6 +234,7 @@ ${DOCKER_COMPOSE_COMMAND} \
 if [[ "${WARDEN_PARAMS[0]}" == "stop" || "${WARDEN_PARAMS[0]}" == "down" || \
       "${WARDEN_PARAMS[0]}" == "up" || "${WARDEN_PARAMS[0]}" == "start" ]]; then
     regeneratePMAConfig
+    regenerateCloudflaredConfig
 fi
 
 ## resume mutagen sync if available and php-fpm container id hasn't changed

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -106,6 +106,12 @@ fi
 [[ ${WARDEN_VARNISH} -eq 1 ]] \
     && appendEnvPartialIfExists "varnish"
 
+if [[ ${WARDEN_QUICK_TUNNEL:-0} -eq 1 ]]; then
+    appendEnvPartialIfExists "quick-tunnel"
+    [[ ${WARDEN_VARNISH} -eq 1 ]] \
+        && appendEnvPartialIfExists "quick-tunnel-varnish"
+fi
+
 [[ ${WARDEN_RABBITMQ} -eq 1 ]] \
     && appendEnvPartialIfExists "rabbitmq"
 

--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -29,6 +29,9 @@ if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
 
     # Check PMA
     eval "$(grep "^WARDEN_PHPMYADMIN_ENABLE" "${WARDEN_HOME_DIR}/.env")"
+
+    # Check Cloudflared
+    eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
 fi
 
 export WARDEN_DOCKER_SOCK="${WARDEN_DOCKER_SOCK:-/var/run/docker.sock}"
@@ -59,6 +62,12 @@ if [[ "${WARDEN_PHPMYADMIN_ENABLE}" == 1 ]]; then
     fi
     DOCKER_COMPOSE_ARGS+=("-f")
     DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/docker-compose.phpmyadmin.yml")
+fi
+
+## add cloudflared docker-compose
+if [[ -n "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/docker-compose.cloudflared.yml")
 fi
 
 ## allow an additional docker-compose file to be loaded for global services
@@ -128,4 +137,6 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
     if [[ "${WARDEN_PHPMYADMIN_ENABLE}" == 1 ]]; then
         regeneratePMAConfig
     fi
+
+    regenerateCloudflaredConfig
 fi

--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -31,7 +31,7 @@ if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
     eval "$(grep "^WARDEN_PHPMYADMIN_ENABLE" "${WARDEN_HOME_DIR}/.env")"
 
     # Check Cloudflared
-    eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+    eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env" | tr -d '\r')"
 fi
 
 export WARDEN_DOCKER_SOCK="${WARDEN_DOCKER_SOCK:-/var/run/docker.sock}"

--- a/docker/docker-compose.cloudflared.yml
+++ b/docker/docker-compose.cloudflared.yml
@@ -1,0 +1,10 @@
+services:
+  cloudflared:
+    container_name: cloudflared
+    image: ${WARDEN_IMAGE_REPOSITORY:-docker.io/wardenenv}/cloudflared:latest
+    command: tunnel --config /home/nonroot/.cloudflared/config.yml run
+    volumes:
+      - ${WARDEN_HOME_DIR}/etc/cloudflared:/home/nonroot/.cloudflared
+    labels:
+      - traefik.enable=false
+    restart: ${WARDEN_RESTART_POLICY:-always}

--- a/environments/includes/nginx-public.base.yml
+++ b/environments/includes/nginx-public.base.yml
@@ -1,6 +1,7 @@
 services:
   nginx:
     labels:
+      - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx-public.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx-public.priority=2
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx-public.rule=

--- a/environments/includes/nginx-public.base.yml
+++ b/environments/includes/nginx-public.base.yml
@@ -1,0 +1,10 @@
+services:
+  nginx:
+    labels:
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx-public.tls=true
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx-public.priority=2
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx-public.rule=
+          HostRegexp(`{subdomain:.+}.${TRAEFIK_PUBLIC_DOMAIN}`) || Host(`${TRAEFIK_PUBLIC_DOMAIN}`)
+      - traefik.http.services.${WARDEN_ENV_NAME}-nginx-public.loadbalancer.server.port=80
+      - traefik.docker.network=${WARDEN_ENV_NAME}_default
+      - dev.warden.cf.domain=${TRAEFIK_PUBLIC_DOMAIN}

--- a/environments/includes/quick-tunnel-varnish.base.yml
+++ b/environments/includes/quick-tunnel-varnish.base.yml
@@ -1,0 +1,5 @@
+services:
+  quick-tunnel:
+    command: tunnel --url http://varnish:80
+    depends_on:
+      - varnish

--- a/environments/includes/quick-tunnel.base.yml
+++ b/environments/includes/quick-tunnel.base.yml
@@ -1,0 +1,9 @@
+services:
+  quick-tunnel:
+    image: ${WARDEN_IMAGE_REPOSITORY:-docker.io/wardenenv}/cloudflared:latest
+    command: tunnel --url http://nginx:80
+    labels:
+      - traefik.enable=false
+    depends_on:
+      - nginx
+    restart: ${WARDEN_RESTART_POLICY:-always}

--- a/utils/core.sh
+++ b/utils/core.sh
@@ -99,3 +99,54 @@ function regeneratePMAConfig() {
     >&2 echo "phpMyAdmin configuration regenerated."
   fi
 }
+
+function regenerateCloudflaredConfig() {
+  if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+    eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+  fi
+
+  if [[ -z "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then
+    return 0
+  fi
+
+  ## find credentials file (either credentials.json or <uuid>.json)
+  local credentials_file=""
+  if [[ -f "${WARDEN_HOME_DIR}/etc/cloudflared/${WARDEN_CLOUDFLARED_TUNNEL_ID}.json" ]]; then
+    credentials_file="/home/nonroot/.cloudflared/${WARDEN_CLOUDFLARED_TUNNEL_ID}.json"
+  elif [[ -f "${WARDEN_HOME_DIR}/etc/cloudflared/credentials.json" ]]; then
+    credentials_file="/home/nonroot/.cloudflared/credentials.json"
+  else
+    warning "Cloudflared credentials file not found. Run 'warden cf create' first."
+    return 0
+  fi
+
+  >&2 echo "Regenerating cloudflared configuration..."
+  local config_dir="${WARDEN_HOME_DIR}/etc/cloudflared"
+  mkdir -p "${config_dir}"
+
+  local config_file="${config_dir}/config.yml"
+  {
+    echo "tunnel: ${WARDEN_CLOUDFLARED_TUNNEL_ID}"
+    echo "credentials-file: ${credentials_file}"
+    echo ""
+    echo "ingress:"
+
+    for domain in $(docker ps --filter "label=dev.warden.cf.domain" --format '{{.Label "dev.warden.cf.domain"}}' 2>/dev/null | sort -u); do
+      echo "  - hostname: ${domain}"
+      echo "    service: https://traefik"
+      echo "    originRequest:"
+      echo "      noTLSVerify: true"
+      echo "  - hostname: \"*.${domain}\""
+      echo "    service: https://traefik"
+      echo "    originRequest:"
+      echo "      noTLSVerify: true"
+    done
+
+    echo "  - service: http_status:404"
+  } > "${config_file}"
+
+  >&2 echo "Cloudflared configuration regenerated."
+
+  ## restart cloudflared container if it is running
+  docker restart cloudflared 2>/dev/null || true
+}

--- a/utils/core.sh
+++ b/utils/core.sh
@@ -102,7 +102,7 @@ function regeneratePMAConfig() {
 
 function regenerateCloudflaredConfig() {
   if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
-    eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env")"
+    eval "$(grep "^WARDEN_CLOUDFLARED_TUNNEL_ID" "${WARDEN_HOME_DIR}/.env" | tr -d '\r')"
   fi
 
   if [[ -z "${WARDEN_CLOUDFLARED_TUNNEL_ID:-}" ]]; then


### PR DESCRIPTION
## Summary

Adds Quick Tunnel support on top of the Cloudflare Tunnel integration (#923). Quick Tunnels provide instant public URLs without requiring a Cloudflare account, custom domain, or any setup.

- New `WARDEN_QUICK_TUNNEL=1` project-level toggle adds a cloudflared container to the project compose
- Routes through varnish when `WARDEN_VARNISH=1`, otherwise through nginx directly
- New `warden cf quick` command extracts and displays the random `*.trycloudflare.com` URL
- CHANGELOG entry added

## How it works

```
Internet → Cloudflare Edge → quick-tunnel container → varnish/nginx → php-fpm
```

No login, no credentials, no DNS configuration. Just:
```bash
# Add to project .env
WARDEN_QUICK_TUNNEL=1

# Start the project
warden env up

# Get the URL
warden cf quick
```

## Depends on
- ⚠️ **Must be merged AFTER #923** (Cloudflare Tunnel integration) — this branch is based on #923's branch

## Related PRs
- wardenenv/warden#923 — Cloudflare Tunnel integration (base)
- wardenenv/images#104 — Docker image
- wardenenv/docs#53 — Documentation

## Test plan
- [ ] Add `WARDEN_QUICK_TUNNEL=1` to a project `.env`, run `warden env up`
- [ ] Verify `quick-tunnel` container is running: `warden env ps`
- [ ] Verify `warden cf quick` shows the `*.trycloudflare.com` URL
- [ ] With `WARDEN_VARNISH=1`, verify cloudflared routes to varnish
- [ ] Without varnish, verify cloudflared routes to nginx
- [ ] Without `WARDEN_QUICK_TUNNEL`, verify no extra container is added
