### PR TITLE
[draft] [FEATURE] Use Traefik 3 with default syntax to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## UNRELEASED
 [All Commits](https://github.com/wardenenv/warden/compare/0.16.0..main)
 
+**Big Changes:**
+* Traefik has been updated from v2 to v3.  For compatibility, we have kept the v2 rule engine as the default.  It is possible to opt-in to v3 rule syntax on a per-router basis.
+
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)
 * Fix WARDEN_DOCKER_SOCK error running `warden sign-certificate` ([#907](https://github.com/wardenenv/warden/issues/907) by @bap14)

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -26,4 +26,4 @@ global:
 # v2 BC compatibility for router rule syntax (global default) @see https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#step-1-prepare-configurations-and-test-v3
 # v3 rule syntax is opt-in per router via label traefik.http.routers.some-router.ruleSyntax=v3
 core:
-  defaultRuleSyntax: v2  
+  defaultRuleSyntax: v2

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -23,7 +23,7 @@ log:
 global:
   checkNewVersion: false
   sendAnonymousUsage: false
-# v2 BC compatibility for global services @see https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#step-1-prepare-configurations-and-test-v3
-# v3 is opt-in via label traefik.http.routers.some-router.ruleSyntax=v3
+# v2 BC compatibility for router rule syntax (global default) @see https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#step-1-prepare-configurations-and-test-v3
+# v3 rule syntax is opt-in per router via label traefik.http.routers.some-router.ruleSyntax=v3
 core:
   defaultRuleSyntax: v2  

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -23,3 +23,7 @@ log:
 global:
   checkNewVersion: false
   sendAnonymousUsage: false
+# v2 BC compatibility for global services @see https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#step-1-prepare-configurations-and-test-v3
+# v3 is opt-in via label traefik.http.routers.some-router.ruleSyntax=v3
+core:
+  defaultRuleSyntax: v2  

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   traefik:
     container_name: traefik
-    image: traefik:${TRAEFIK_VERSION:-2.11}
+    image: traefik:${TRAEFIK_VERSION:-3.6}
     ports:
       - "${TRAEFIK_LISTEN:-127.0.0.1}:80:80"     # The HTTP port
       - "${TRAEFIK_LISTEN:-127.0.0.1}:443:443"   # The HTTPS port


### PR DESCRIPTION
<!-- [FEATURE] Feel free to delete everything between the [FEATURE] tags if not a new feature -->
**Check List**
- [ ] Matching PR in the documentation repo (replace text with link when it exists)
- [ ] Entry in CHANGELOG.md

**Is your feature request related to a problem? Please describe.**  
Traefik v3 allows more advanced routing with new regexp labels. But at the same time it introduces breaking changes.
I suggest upgrading to Traefik 3+ but pinning default syntax to v2. 
https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#step-1-prepare-configurations-and-test-v3

Anyone wanting v3 syntax that usually applicable to custom services only can opt-in via label.
https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3-details/#configure-the-syntax-per-router
```
labels:
  - "traefik.http.routers.test.ruleSyntax=v3"
```

**Describe the solution you've submitted**  
Allow on demand v3 labels routing.
e.g.
```
QueryRegexp(`PARAM_PREFIX_.*`, `.+`)
```

**Describe alternatives you've considered** 
- Routing via intermediate container. 
- Using `TRAEFIK_VERSION` + custom config. But still if v3 labels used on custom services **my colleagues need to use traefik 3 too**. So opt-in per custom service looks like a decent trade off.

**Additional context**  
I quickly tested this branch on my containers and it seems to be working fine. 
Warden's built-in services do not use labels affected by breaking changes.
Maybe migration script can be considered for `warden env start`, `warden svc up` that automatically updates legacy labels on old projects.
I invite for discussion and community tests. 

<!-- [/FEATURE] -->